### PR TITLE
travis-ci.org instead of travis-ci.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # kube-metrics-adapter
-[![Build Status](https://travis-ci.com/zalando-incubator/kube-metrics-adapter.svg?branch=master)](https://travis-ci.com/zalando-incubator/kube-metrics-adapter)
+[![Build Status](https://travis-ci.org/zalando-incubator/kube-metrics-adapter.svg?branch=master)](https://travis-ci.org/zalando-incubator/kube-metrics-adapter)
 
 Kube Metrics Adapter is a general purpose metrics adapter for Kubernetes that
 can collect and serve custom and external metrics for Horizontal Pod


### PR DESCRIPTION
The build was registered at travis-ci.org not .com.