### PR TITLE
Skipper metrics collection for resource types

### DIFF
--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -287,6 +287,8 @@ func ParseHPAMetrics(hpa *autoscalingv2beta1.HorizontalPodAutoscaler) ([]*Metric
 			}
 		case autoscalingv2beta1.ExternalMetricSourceType:
 			typeName.Name = metric.External.MetricName
+		case autoscalingv2beta1.ResourceMetricSourceType:
+			continue // kube-metrics-adapter does not collect resource metrics
 		}
 
 		if config, ok := configs[typeName]; ok {


### PR DESCRIPTION
Signed-off-by: Arjun Naik <arjun.rn@gmail.com>

The adapter attempts to collect metrics for `Resource` type and then records warnings in the HPAs. This should prevent that.