### PR TITLE
Look at total replicas instead of readyReplicas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 build/
 apiserver.local.config/
+.idea/
+vendor/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: go
+dist: xenial
 
 go:
   - "1.11.2"

--- a/pkg/collector/skipper_collector.go
+++ b/pkg/collector/skipper_collector.go
@@ -152,13 +152,13 @@ func targetRefReplicas(client kubernetes.Interface, hpa *autoscalingv2beta1.Hori
 		if err != nil {
 			return 0, err
 		}
-		replicas = deployment.Status.ReadyReplicas
+		replicas = deployment.Status.replicas
 	case "StatefulSet":
 		sts, err := client.AppsV1().StatefulSets(hpa.Namespace).Get(hpa.Spec.ScaleTargetRef.Name, metav1.GetOptions{})
 		if err != nil {
 			return 0, err
 		}
-		replicas = sts.Status.ReadyReplicas
+		replicas = sts.Status.replicas
 	}
 
 	return replicas, nil

--- a/pkg/collector/skipper_collector.go
+++ b/pkg/collector/skipper_collector.go
@@ -152,13 +152,13 @@ func targetRefReplicas(client kubernetes.Interface, hpa *autoscalingv2beta1.Hori
 		if err != nil {
 			return 0, err
 		}
-		replicas = deployment.Status.replicas
+		replicas = deployment.Status.Replicas
 	case "StatefulSet":
 		sts, err := client.AppsV1().StatefulSets(hpa.Namespace).Get(hpa.Spec.ScaleTargetRef.Name, metav1.GetOptions{})
 		if err != nil {
 			return 0, err
 		}
-		replicas = sts.Status.replicas
+		replicas = sts.Status.Replicas
 	}
 
 	return replicas, nil

--- a/pkg/collector/skipper_collector_test.go
+++ b/pkg/collector/skipper_collector_test.go
@@ -1,0 +1,87 @@
+package collector
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/api/apps/v1"
+	autoscalingv2beta1 "k8s.io/api/autoscaling/v2beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestTargetRefReplicasDeployments(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	name := "some-app"
+	defaultNamespace := "default"
+	deployment, err := newDeployment(client, defaultNamespace, name)
+	require.NoError(t, err)
+
+	// Create an HPA with the deployment as ref
+	hpa, err := client.AutoscalingV2beta1().HorizontalPodAutoscalers(deployment.Namespace).
+		Create(newHPA(defaultNamespace, name, "Deployment"))
+	require.NoError(t, err)
+
+	replicas, err := targetRefReplicas(client, hpa)
+	require.NoError(t, err)
+	require.Equal(t, deployment.Status.Replicas, replicas)
+}
+
+func TestTargetRefReplicasStatefulSets(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	name := "some-app"
+	defaultNamespace := "default"
+	statefulSet, err := newStatefulSet(client, defaultNamespace, name)
+	require.NoError(t, err)
+
+	// Create an HPA with the statefulSet as ref
+	hpa, err := client.AutoscalingV2beta1().HorizontalPodAutoscalers(statefulSet.Namespace).
+		Create(newHPA(defaultNamespace, name, "StatefulSet"))
+	require.NoError(t, err)
+
+	replicas, err := targetRefReplicas(client, hpa)
+	require.NoError(t, err)
+	require.Equal(t, statefulSet.Status.Replicas, replicas)
+}
+
+func newHPA(namesapce string, refName string, refKind string) *autoscalingv2beta1.HorizontalPodAutoscaler {
+	return &autoscalingv2beta1.HorizontalPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: namesapce,
+		},
+		Spec: autoscalingv2beta1.HorizontalPodAutoscalerSpec{
+			ScaleTargetRef: autoscalingv2beta1.CrossVersionObjectReference{
+				Name: refName,
+				Kind: refKind,
+			},
+		},
+		Status: autoscalingv2beta1.HorizontalPodAutoscalerStatus{},
+	}
+}
+
+func newDeployment(client *fake.Clientset, namespace string, name string) (*v1.Deployment, error) {
+	return client.AppsV1().Deployments(namespace).Create(&v1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: v1.DeploymentSpec{},
+		Status: v1.DeploymentStatus{
+			ReadyReplicas: 1,
+			Replicas:      2,
+		},
+	})
+}
+
+func newStatefulSet(client *fake.Clientset, namespace string, name string) (*v1.StatefulSet, error) {
+	return client.AppsV1().StatefulSets(namespace).Create(&v1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Status: v1.StatefulSetStatus{
+			ReadyReplicas: 1,
+			Replicas:      2,
+		},
+	})
+}


### PR DESCRIPTION
In cases where replicas take a bit of time to get ready, the Stackset Controller just keeps on scaling. To avoid this issue, using the total replicas instead of replicas that are ready.

## Types of Changes
_What types of changes does your code introduce? Keep the ones that apply:_

- Bug fix (non-breaking change which fixes an issue)

## Tasks
_List of tasks you will do to complete the PR_
  - [x] Merge Fix
  - [x] Add a test to avoid regression
  - [ ] Roll out
