### PR TITLE
Fix json serialization naming for zmon queries

### DIFF
--- a/pkg/zmon/zmon.go
+++ b/pkg/zmon/zmon.go
@@ -71,7 +71,7 @@ type metric struct {
 	Limit       int                 `json:"limit"`
 	Tags        map[string][]string `json:"tags"`
 	GroupBy     []tagGroup          `json:"group_by"`
-	Aggregators []aggregator        `json:"aggregator"`
+	Aggregators []aggregator        `json:"aggregators"`
 }
 
 type tagGroup struct {


### PR DESCRIPTION
Fix json serialization naming for zmon queries

## Description
When querying zmon/KairosDB aggregators did not work since json field name was wrong. 
Therefore multi-entity queries used to get only last values. This PR aims to fix it

## Types of Changes

- New feature (non-breaking change which adds functionality)

## Review
- [x] Tests
- [ ] Documentation
- [ ] CHANGELOG

