### PR TITLE
Added weighting of RPS metrics based on backend weights

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,16 @@ spec:
       targetValue: 10 # this will be treated as targetAverageValue
 ```
 
+### Metric weighting based on backend
+
+Skipper supports sending traffic to different backend based on annotations present on the
+`Ingress` object. When the metric name is specified without a backend as `requests-per-second`
+then the number of replicas will be calculated based on the full traffic served by that ingress.
+If however only the traffic being routed to a specific backend should be used then the
+backend name can be specified as a metric name like `requests-per-second|backend1` which would
+return the requests-per-second being sent to the `backend1`.
+
+
 **Note:** As of Kubernetes v1.10 the HPA does not support `targetAverageValue` for
 metrics of type `Object`. In case of requests per second it does not make sense
 to scale on a summed value because you can not make the total requests per

--- a/README.md
+++ b/README.md
@@ -246,8 +246,9 @@ Skipper supports sending traffic to different backend based on annotations prese
 `Ingress` object. When the metric name is specified without a backend as `requests-per-second`
 then the number of replicas will be calculated based on the full traffic served by that ingress.
 If however only the traffic being routed to a specific backend should be used then the
-backend name can be specified as a metric name like `requests-per-second|backend1` which would
-return the requests-per-second being sent to the `backend1`.
+backend name can be specified as a metric name like `requests-per-second/backend1` which would
+return the requests-per-second being sent to the `backend1`. The ingress annotation where
+the backend weights can be obtained can be specified through the flag `--skipper-backends-annotation`.
 
 
 **Note:** As of Kubernetes v1.10 the HPA does not support `targetAverageValue` for

--- a/pkg/collector/max_collector.go
+++ b/pkg/collector/max_collector.go
@@ -1,42 +1,54 @@
 package collector
 
-import "time"
+import (
+	"fmt"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"time"
+)
 
-// MaxCollector is a simple aggregator collector that returns the maximum value
+// MaxWeightedCollector is a simple aggregator collector that returns the maximum value
 // of metrics from all collectors.
-type MaxCollector struct {
+type MaxWeightedCollector struct {
 	collectors []Collector
 	interval   time.Duration
+	weight     float64
 }
 
 // NewMaxCollector initializes a new MacCollector.
-func NewMaxCollector(interval time.Duration, collectors ...Collector) *MaxCollector {
-	return &MaxCollector{
+func NewMaxWeightedCollector(interval time.Duration, weight float64, collectors ...Collector) *MaxWeightedCollector {
+	return &MaxWeightedCollector{
 		collectors: collectors,
 		interval:   interval,
+		weight:     weight,
 	}
 }
 
 // GetMetrics gets metrics from all collectors and return the higest value.
-func (c *MaxCollector) GetMetrics() ([]CollectedMetric, error) {
-	var max CollectedMetric
+func (c *MaxWeightedCollector) GetMetrics() ([]CollectedMetric, error) {
+	collectedMetrics := make([]CollectedMetric, 0)
 	for _, collector := range c.collectors {
 		values, err := collector.GetMetrics()
 		if err != nil {
 			return nil, err
 		}
-
-		for _, value := range values {
-			if value.Custom.Value.MilliValue() > max.Custom.Value.MilliValue() {
-				max = value
-			}
+		for _, v := range values {
+			collectedMetrics = append(collectedMetrics, v)
 		}
-
 	}
+	if len(collectedMetrics) == 0 {
+		return nil, fmt.Errorf("no metrics collected, cannot determine max")
+	}
+	max := collectedMetrics[0]
+	for _, value := range collectedMetrics {
+		if value.Custom.Value.MilliValue() > max.Custom.Value.MilliValue() {
+			max = value
+		}
+	}
+	max.Custom.Value = *resource.NewMilliQuantity(int64(c.weight*float64(max.Custom.Value.MilliValue())), resource.DecimalSI)
 	return []CollectedMetric{max}, nil
 }
 
 // Interval returns the interval at which the collector should run.
-func (c *MaxCollector) Interval() time.Duration {
+func (c *MaxWeightedCollector) Interval() time.Duration {
 	return c.interval
 }

--- a/pkg/collector/skipper_collector.go
+++ b/pkg/collector/skipper_collector.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"k8s.io/apimachinery/pkg/api/resource"
-	"math"
 	"strings"
 	"time"
 
@@ -17,22 +16,23 @@ import (
 const (
 	rpsQuery                  = `scalar(sum(rate(skipper_serve_host_duration_seconds_count{host="%s"}[1m])))`
 	rpsMetricName             = "requests-per-second"
-	stacksetWeightsAnnotation = "zalando.org/stack-traffic-weights"
-	backendWeightsAnnotation  = "zalando.org/backend-weights"
+	rpsMetricBackendSeparator = "/"
 )
 
 // SkipperCollectorPlugin is a collector plugin for initializing metrics
 // collectors for getting skipper ingress metrics.
 type SkipperCollectorPlugin struct {
-	client kubernetes.Interface
-	plugin CollectorPlugin
+	client            kubernetes.Interface
+	plugin            CollectorPlugin
+	backendAnnotation string
 }
 
 // NewSkipperCollectorPlugin initializes a new SkipperCollectorPlugin.
-func NewSkipperCollectorPlugin(client kubernetes.Interface, prometheusPlugin *PrometheusCollectorPlugin) (*SkipperCollectorPlugin, error) {
+func NewSkipperCollectorPlugin(client kubernetes.Interface, prometheusPlugin *PrometheusCollectorPlugin, backendAnnotation string) (*SkipperCollectorPlugin, error) {
 	return &SkipperCollectorPlugin{
-		client: client,
-		plugin: prometheusPlugin,
+		client:            client,
+		plugin:            prometheusPlugin,
+		backendAnnotation: backendAnnotation,
 	}, nil
 }
 
@@ -41,12 +41,12 @@ func (c *SkipperCollectorPlugin) NewCollector(hpa *autoscalingv2beta1.Horizontal
 	if strings.HasPrefix(config.Name, rpsMetricName) {
 		backend := ""
 		if len(config.Name) > len(rpsMetricName) {
-			metricNameParts := strings.Split(config.Name, ",")
+			metricNameParts := strings.Split(config.Name, rpsMetricBackendSeparator)
 			if len(metricNameParts) == 2 {
 				backend = metricNameParts[1]
 			}
 		}
-		return NewSkipperCollector(c.client, c.plugin, hpa, config, interval, backend)
+		return NewSkipperCollector(c.client, c.plugin, hpa, config, interval, c.backendAnnotation, backend)
 	}
 	return nil, fmt.Errorf("metric '%s' not supported", config.Name)
 }
@@ -54,52 +54,48 @@ func (c *SkipperCollectorPlugin) NewCollector(hpa *autoscalingv2beta1.Horizontal
 // SkipperCollector is a metrics collector for getting skipper ingress metrics.
 // It depends on the prometheus collector for getting the metrics.
 type SkipperCollector struct {
-	client          kubernetes.Interface
-	metricName      string
-	objectReference custom_metrics.ObjectReference
-	hpa             *autoscalingv2beta1.HorizontalPodAutoscaler
-	interval        time.Duration
-	plugin          CollectorPlugin
-	config          MetricConfig
-	backend         string
+	client            kubernetes.Interface
+	metricName        string
+	objectReference   custom_metrics.ObjectReference
+	hpa               *autoscalingv2beta1.HorizontalPodAutoscaler
+	interval          time.Duration
+	plugin            CollectorPlugin
+	config            MetricConfig
+	backend           string
+	backendAnnotation string
 }
 
 // NewSkipperCollector initializes a new SkipperCollector.
 func NewSkipperCollector(client kubernetes.Interface, plugin CollectorPlugin, hpa *autoscalingv2beta1.HorizontalPodAutoscaler,
-	config *MetricConfig, interval time.Duration, backend string) (*SkipperCollector, error) {
+	config *MetricConfig, interval time.Duration, backendAnnotation, backend string) (*SkipperCollector, error) {
 	return &SkipperCollector{
-		client:          client,
-		objectReference: config.ObjectReference,
-		hpa:             hpa,
-		metricName:      config.Name,
-		interval:        interval,
-		plugin:          plugin,
-		config:          *config,
-		backend:         backend,
+		client:            client,
+		objectReference:   config.ObjectReference,
+		hpa:               hpa,
+		metricName:        config.Name,
+		interval:          interval,
+		plugin:            plugin,
+		config:            *config,
+		backend:           backend,
+		backendAnnotation: backendAnnotation,
 	}, nil
 }
 
 func getAnnotationWeight(annotations map[string]string, annotation, backend string) float64 {
+	if annotation == "" || backend == "" {
+		return 1
+	}
 	if weightsMap, ok := annotations[annotation]; ok {
 		var backendWeights map[string]int
 		err := json.Unmarshal([]byte(weightsMap), &backendWeights)
 		if err != nil {
-			return 0
+			return 1
 		}
 		if selectedWeight, ok := backendWeights[backend]; ok {
 			return float64(selectedWeight) / 100
 		}
 	}
-	return 0
-}
-
-func getWeights(annotations map[string]string, backend string) float64 {
-	stacksetWeight := getAnnotationWeight(annotations, stacksetWeightsAnnotation, backend)
-	backendWeight := getAnnotationWeight(annotations, backendWeightsAnnotation, backend)
-	if stacksetWeight == 0 && backendWeight == 0 {
-		return 1.0
-	}
-	return math.Max(stacksetWeight, backendWeight)
+	return 1
 }
 
 // getCollector returns a collector for getting the metrics.
@@ -108,7 +104,7 @@ func (c *SkipperCollector) getCollector() (Collector, error) {
 	if err != nil {
 		return nil, err
 	}
-	backendWeight := getWeights(ingress.Annotations, c.backend)
+	backendWeight := getAnnotationWeight(ingress.Annotations, c.backendAnnotation, c.backend)
 	config := c.config
 
 	var collector Collector

--- a/pkg/server/start.go
+++ b/pkg/server/start.go
@@ -98,7 +98,7 @@ func NewCommandStartAdapterServer(stopCh <-chan struct{}) *cobra.Command {
 		"path to the credentials dir where tokens are stored")
 	flags.BoolVar(&o.SkipperIngressMetrics, "skipper-ingress-metrics", o.SkipperIngressMetrics, ""+
 		"whether to enable skipper ingress metrics")
-	flags.StringVar(&o.SkipperBackendWeightAnnotation, "skipper-backends-annotation", o.SkipperBackendWeightAnnotation, ""+
+	flags.StringArrayVar(&o.SkipperBackendWeightAnnotation, "skipper-backends-annotation", o.SkipperBackendWeightAnnotation, ""+
 		"the annotation to get backend weights so that the returned metric can be weighted")
 	flags.BoolVar(&o.AWSExternalMetrics, "aws-external-metrics", o.AWSExternalMetrics, ""+
 		"whether to enable AWS external metrics")
@@ -309,5 +309,5 @@ type AdapterServerOptions struct {
 	// MetricsAddress is the address where to serve prometheus metrics.
 	MetricsAddress string
 	// SkipperBackendWeightAnnotation is the annotation on the ingress indicating the backend weights
-	SkipperBackendWeightAnnotation string
+	SkipperBackendWeightAnnotation []string
 }

--- a/pkg/server/start.go
+++ b/pkg/server/start.go
@@ -98,6 +98,8 @@ func NewCommandStartAdapterServer(stopCh <-chan struct{}) *cobra.Command {
 		"path to the credentials dir where tokens are stored")
 	flags.BoolVar(&o.SkipperIngressMetrics, "skipper-ingress-metrics", o.SkipperIngressMetrics, ""+
 		"whether to enable skipper ingress metrics")
+	flags.StringVar(&o.SkipperBackendWeightAnnotation, "skipper-backends-annotation", o.SkipperBackendWeightAnnotation, ""+
+		"the annotation to get backend weights so that the returned metric can be weighted")
 	flags.BoolVar(&o.AWSExternalMetrics, "aws-external-metrics", o.AWSExternalMetrics, ""+
 		"whether to enable AWS external metrics")
 	flags.StringSliceVar(&o.AWSRegions, "aws-region", o.AWSRegions, "the AWS regions which should be monitored. eg: eu-central, eu-west-1")
@@ -159,7 +161,7 @@ func (o AdapterServerOptions) RunCustomMetricsAdapterServer(stopCh <-chan struct
 
 		// skipper collector can only be enabled if prometheus is.
 		if o.SkipperIngressMetrics {
-			skipperPlugin, err := collector.NewSkipperCollectorPlugin(client, promPlugin)
+			skipperPlugin, err := collector.NewSkipperCollectorPlugin(client, promPlugin, o.SkipperBackendWeightAnnotation)
 			if err != nil {
 				return fmt.Errorf("failed to initialize skipper collector plugin: %v", err)
 			}
@@ -306,4 +308,6 @@ type AdapterServerOptions struct {
 	AWSRegions []string
 	// MetricsAddress is the address where to serve prometheus metrics.
 	MetricsAddress string
+	// SkipperBackendWeightAnnotation is the annotation on the ingress indicating the backend weights
+	SkipperBackendWeightAnnotation string
 }


### PR DESCRIPTION
# Weighting RPS metrics based on weight annotations

## Description
The backend weights for skipper ingress are stored as annotations in the ingress object. These are used to weight the returned metrics. Also the `request-per-second` metric name also contains the backend name.

## Types of Changes
- Weighting of RPS metrics
- Bug fix for when the MaxCollector gets only zero values

## Review
_List of tasks the reviewer must do to review the PR_
- [x] Tests
- [x] Documentation
