### PR TITLE
Added missing logic and test case when weight of backend is 0

### DIFF
--- a/pkg/collector/skipper_collector.go
+++ b/pkg/collector/skipper_collector.go
@@ -94,7 +94,7 @@ func getAnnotationWeight(backendWeights string, backend string) float64 {
 }
 
 func getWeights(ingressAnnotations map[string]string, backendAnnotations []string, backend string) float64 {
-	var maxWeight float64 = 0
+	var maxWeight float64 = -1
 	for _, anno := range backendAnnotations {
 		if weightsMap, ok := ingressAnnotations[anno]; ok {
 			weight := getAnnotationWeight(weightsMap, backend)
@@ -103,7 +103,7 @@ func getWeights(ingressAnnotations map[string]string, backendAnnotations []strin
 			}
 		}
 	}
-	if maxWeight > 0 {
+	if maxWeight >= 0 {
 		return maxWeight
 	}
 	return 1.0

--- a/pkg/collector/skipper_collector_test.go
+++ b/pkg/collector/skipper_collector_test.go
@@ -148,6 +148,18 @@ func TestSkipperCollector(t *testing.T) {
 			backendAnnotations: []string{testBackendWeightsAnnotation},
 		},
 		{
+			msg:                "test zero weight backends",
+			metrics:            []int{100, 1500, 700},
+			ingressName:        "dummy-ingress",
+			collectedMetric:    0,
+			namespace:          "default",
+			backend:            "backend1",
+			backendWeights:     map[string]map[string]int{testBackendWeightsAnnotation: {"backend2": 100, "backend1": 0}},
+			replicas:           5,
+			readyReplicas:      5,
+			backendAnnotations: []string{testBackendWeightsAnnotation},
+		},
+		{
 			msg:             "test multiple backend annotation",
 			metrics:         []int{100, 1500, 700},
 			ingressName:     "dummy-ingress",


### PR DESCRIPTION
The case when the backend weight was zero was not handled and it was falling back to the logic when the weight is not set. This PR addresses that issue and adds a corresponding test.