### PR TITLE
Fix case when backend is not set

### DIFF
--- a/pkg/collector/skipper_collector.go
+++ b/pkg/collector/skipper_collector.go
@@ -85,12 +85,12 @@ func getAnnotationWeight(backendWeights string, backend string) float64 {
 	var weightsMap map[string]int
 	err := json.Unmarshal([]byte(backendWeights), &weightsMap)
 	if err != nil {
-		return 0
+		return 1
 	}
 	if weight, ok := weightsMap[backend]; ok {
 		return float64(weight) / 100
 	}
-	return 0
+	return 1
 }
 
 func getWeights(ingressAnnotations map[string]string, backendAnnotations []string, backend string) float64 {

--- a/pkg/collector/skipper_collector_test.go
+++ b/pkg/collector/skipper_collector_test.go
@@ -174,6 +174,18 @@ func TestSkipperCollector(t *testing.T) {
 			readyReplicas:      5,
 			backendAnnotations: []string{testBackendWeightsAnnotation, testStacksetWeightsAnnotation},
 		},
+		{
+			msg:                "test backend is not set",
+			metrics:            []int{100, 1500, 700},
+			ingressName:        "dummy-ingress",
+			collectedMetric:    1500,
+			namespace:          "default",
+			backend:            "",
+			backendWeights:     map[string]map[string]int{testBackendWeightsAnnotation: {"backend2": 100, "backend1": 0}},
+			replicas:           1,
+			readyReplicas:      1,
+			backendAnnotations: []string{testBackendWeightsAnnotation},
+		},
 	} {
 		t.Run(tc.msg, func(tt *testing.T) {
 			client := fake.NewSimpleClientset()


### PR DESCRIPTION
When the backend is not specified in the metric name the weight is defaults to zero. It should instead be 1 otherwise the `request-per-second` metric is useless.