### PR TITLE
Fix nil dereference panics for the Annotation config parser

### DIFF
--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -174,7 +174,7 @@ func ParseHPAMetrics(hpa *autoscalingv2.HorizontalPodAutoscaler) ([]*MetricConfi
 
 	// TODO: validate that the specified metric names are defined
 	// in the HPA
-	var parser annotations.AnnotationConfigMap
+	parser := make(annotations.AnnotationConfigMap)
 	err := parser.Parse(hpa.Annotations)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
The annotation config parser was not initialized correctly.