### PR TITLE
Add the labels from the zmon check into the config object

### DIFF
--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -209,6 +209,10 @@ func ParseHPAMetrics(hpa *autoscalingv2.HorizontalPodAutoscaler) ([]*MetricConfi
 			Config:          map[string]string{},
 		}
 
+		if metric.Type == autoscalingv2.ExternalMetricSourceType {
+			config.Config = metric.External.Metric.Selector.MatchLabels
+		}
+
 		annotationConfigs, present := parser.GetAnnotationConfig(typeName.Metric.Name, typeName.Type)
 		if present {
 			config.CollectorName = annotationConfigs.CollectorName


### PR DESCRIPTION
In a previous PR #39 [in this file](https://github.com/zalando-incubator/kube-metrics-adapter/pull/39/files#diff-82aaae0c6d8f8f72eeab56f04830af24) while refactoring some code I dropped the code which copies external metric configs into the collector. I've re-added.