### PR TITLE
Remove unused Configuration key from MetricConfig

### DIFF
--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -165,7 +165,6 @@ type MetricConfig struct {
 	ObjectReference custom_metrics.ObjectReference
 	PerReplica      bool
 	Interval        time.Duration
-	Configuration   map[string]string
 }
 
 // ParseHPAMetrics parses the HPA object into a list of metric configurations.

--- a/pkg/collector/zmon_collector.go
+++ b/pkg/collector/zmon_collector.go
@@ -69,7 +69,7 @@ type ZMONCollector struct {
 
 // NewZMONCollector initializes a new ZMONCollector.
 func NewZMONCollector(zmon zmon.ZMON, config *MetricConfig, annotations map[string]string, interval time.Duration) (*ZMONCollector, error) {
-	checkIDStr, ok := config.Configuration[zmonCheckIDLabelKey]
+	checkIDStr, ok := config.Config[zmonCheckIDLabelKey]
 	if !ok {
 		return nil, fmt.Errorf("ZMON check ID not specified on metric")
 	}
@@ -82,7 +82,7 @@ func NewZMONCollector(zmon zmon.ZMON, config *MetricConfig, annotations map[stri
 	key := ""
 
 	// get optional key
-	if k, ok := config.Configuration[zmonKeyLabelKey]; ok {
+	if k, ok := config.Config[zmonKeyLabelKey]; ok {
 		key = k
 	}
 
@@ -94,7 +94,7 @@ func NewZMONCollector(zmon zmon.ZMON, config *MetricConfig, annotations map[stri
 	duration := defaultQueryDuration
 
 	// parse optional duration value
-	if d, ok := config.Configuration[zmonDurationLabelKey]; ok {
+	if d, ok := config.Config[zmonDurationLabelKey]; ok {
 		duration, err = time.ParseDuration(d)
 		if err != nil {
 			return nil, err
@@ -103,7 +103,7 @@ func NewZMONCollector(zmon zmon.ZMON, config *MetricConfig, annotations map[stri
 
 	// parse tags
 	tags := make(map[string]string)
-	for k, v := range config.Configuration {
+	for k, v := range config.Config {
 		if strings.HasPrefix(k, zmonTagPrefixLabelKey) {
 			key := strings.TrimPrefix(k, zmonTagPrefixLabelKey)
 			tags[key] = v
@@ -122,7 +122,7 @@ func NewZMONCollector(zmon zmon.ZMON, config *MetricConfig, annotations map[stri
 
 	// default aggregator is last
 	aggregators := []string{"last"}
-	if k, ok := config.Configuration[zmonAggregatorsLabelKey]; ok {
+	if k, ok := config.Config[zmonAggregatorsLabelKey]; ok {
 		aggregators = strings.Split(k, ",")
 	}
 

--- a/pkg/collector/zmon_collector_test.go
+++ b/pkg/collector/zmon_collector_test.go
@@ -28,7 +28,7 @@ func TestZMONCollectorNewCollector(t *testing.T) {
 		MetricTypeName: MetricTypeName{
 			Metric: newMetricIdentifier(ZMONCheckMetric),
 		},
-		Configuration: map[string]string{
+		Config: map[string]string{
 			zmonCheckIDLabelKey:             "1234",
 			zmonAggregatorsLabelKey:         "max",
 			zmonTagPrefixLabelKey + "alias": "cluster_alias",
@@ -70,7 +70,7 @@ func TestZMONCollectorNewCollector(t *testing.T) {
 	require.Error(t, err)
 
 	// should fail if the check id is not specified.
-	delete(config.Configuration, zmonCheckIDLabelKey)
+	delete(config.Config, zmonCheckIDLabelKey)
 	config.Metric.Name = ZMONCheckMetric
 	_, err = collectPlugin.NewCollector(nil, config, 1*time.Second)
 	require.Error(t, err)
@@ -88,7 +88,7 @@ func TestZMONCollectorGetMetrics(tt *testing.T) {
 			Metric: newMetricIdentifier(ZMONCheckMetric),
 			Type:   "foo",
 		},
-		Configuration: map[string]string{
+		Config: map[string]string{
 			zmonCheckIDLabelKey:             "1234",
 			zmonAggregatorsLabelKey:         "max",
 			zmonTagPrefixLabelKey + "alias": "cluster_alias",


### PR DESCRIPTION
This fixes an issue of setting up a ZMON collector where the incorrect
key `Configuration` was used, which was not initialized in the metrics
config parser. The `Config` key is the right one to use.