### PR TITLE
Allow Prometheus metrics for External target

### DIFF
--- a/pkg/server/start.go
+++ b/pkg/server/start.go
@@ -156,8 +156,10 @@ func (o AdapterServerOptions) RunCustomMetricsAdapterServer(stopCh <-chan struct
 
 		err = collectorFactory.RegisterObjectCollector("", "prometheus", promPlugin)
 		if err != nil {
-			return fmt.Errorf("failed to register prometheus collector plugin: %v", err)
+			return fmt.Errorf("failed to register prometheus object collector plugin: %v", err)
 		}
+
+		collectorFactory.RegisterExternalCollector([]string{collector.PrometheusMetricName}, promPlugin)
 
 		// skipper collector can only be enabled if prometheus is.
 		if o.SkipperIngressMetrics {


### PR DESCRIPTION
Allows specifying Prometheus based metrics as `External` target.

I'm not 100% sure on the format for the annotation. Feedback welcome.

* [x] Still need to test that it actually works this way :)

Fix #45

/cc @timstoop
