### PR TITLE
Document how to use HTTPS for pod collector

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ metadata:
     metric-config.pods.requests-per-second.json-path/json-key: "$.http_server.rps"
     metric-config.pods.requests-per-second.json-path/path: /metrics
     metric-config.pods.requests-per-second.json-path/port: "9090"
+    metric-config.pods.requests-per-second.json-path/scheme: "https"
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
@@ -123,9 +124,9 @@ The json-path query support depends on the
 See the README for possible queries. It's expected that the metric you query
 returns something that can be turned into a `float64`.
 
-The other configuration options `path` and `port` specifies where the metrics
-endpoint is exposed on the pod. There's no default values, so they must be
-defined.
+The other configuration options `path`, `port` and `scheme` specify where the metrics
+endpoint is exposed on the pod. The `path` and `port` options do not have default values
+so they must be defined. The `scheme` is optional and defaults to `http`.
 
 ## Prometheus collector
 

--- a/pkg/annotations/parser_test.go
+++ b/pkg/annotations/parser_test.go
@@ -27,6 +27,7 @@ func TestParser(t *testing.T) {
 				"metric-config.pods.requests-per-second.json-path/json-key": "$.http_server.rps",
 				"metric-config.pods.requests-per-second.json-path/path":     "/metrics",
 				"metric-config.pods.requests-per-second.json-path/port":     "9090",
+				"metric-config.pods.requests-per-second.json-path/scheme":   "https",
 			},
 			MetricName: "requests-per-second",
 			MetricType: autoscalingv2.PodsMetricSourceType,
@@ -34,6 +35,7 @@ func TestParser(t *testing.T) {
 				"json-key": "$.http_server.rps",
 				"path":     "/metrics",
 				"port":     "9090",
+				"scheme":   "https",
 			},
 		},
 		{


### PR DESCRIPTION
# Document the use of HTTPS for the pod metrics collector

> Issue : #62 

## Description
The pod collector can use HTTPS to scrape metrics but this is not documented currently
