### PR TITLE
Use proper tags for docker images

### DIFF
--- a/delivery.yaml
+++ b/delivery.yaml
@@ -18,7 +18,9 @@ pipeline:
     cmd: |
       if [[ $CDP_TARGET_BRANCH == master && ! $CDP_PULL_REQUEST_NUMBER ]]; then
         IMAGE=registry-write.opensource.zalan.do/teapot/kube-metrics-adapter
+        VERSION=$(git describe --tags --always --dirty)
       else
         IMAGE=registry-write.opensource.zalan.do/teapot/kube-metrics-adapter-test
+        VERSION=$CDP_BUILD_VERSION
       fi
-      IMAGE=$IMAGE VERSION=$CDP_BUILD_VERSION make build.push
+      IMAGE=$IMAGE VERSION=$VERSION make build.push


### PR DESCRIPTION
In preparation for cutting the first release we need to correctly tag docker images in our build pipeline.