### PR TITLE
Fix response on no metrics found

### DIFF
--- a/pkg/provider/metric_store.go
+++ b/pkg/provider/metric_store.go
@@ -155,12 +155,12 @@ func (s *MetricStore) GetMetricsBySelector(namespace string, selector labels.Sel
 
 	metrics, ok := s.customMetricsStore[info.Metric]
 	if !ok {
-		return nil
+		return &custom_metrics.MetricValueList{}
 	}
 
 	group, ok := metrics[info.GroupResource]
 	if !ok {
-		return nil
+		return &custom_metrics.MetricValueList{}
 	}
 
 	if !info.Namespaced {

--- a/pkg/provider/metrics_store_test.go
+++ b/pkg/provider/metrics_store_test.go
@@ -568,7 +568,7 @@ func TestCustomMetricsStorageErrors(t *testing.T) {
 			require.Nil(t, metric)
 
 			metrics := metricsStore.GetMetricsBySelector(tc.byLabel.namespace, tc.byLabel.selector, tc.byLabel.info)
-			require.Nil(t, metrics)
+			require.Equal(t, &custom_metrics.MetricValueList{}, metrics)
 
 		})
 	}


### PR DESCRIPTION
Fixes the response from `GetMetricsBySelector` in case no metrics are
found. This issue caused a panic in kube-controller-manager:
https://github.com/kubernetes/kubernetes/pull/80392

Fix #40