### PR TITLE
Add support for averageValue for request-per-second Skipper metric

### DIFF
--- a/example/deploy/hpa.yaml
+++ b/example/deploy/hpa.yaml
@@ -37,7 +37,8 @@ spec:
         apiVersion: extensions/v1beta1
         kind: Ingress
         name: custom-metrics-consumer
-      targetValue: 10 # this will be treated as targetAverageValue
+      averageValue: 10
+      targetValue: 10 # this must be set, but has no effect if `averageValue` is defined.
   - type: External
     external:
       metricName: sqs-queue-length

--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -165,6 +165,7 @@ type MetricConfig struct {
 	ObjectReference custom_metrics.ObjectReference
 	PerReplica      bool
 	Interval        time.Duration
+	MetricSpec      autoscalingv2.MetricSpec
 }
 
 // ParseHPAMetrics parses the HPA object into a list of metric configurations.
@@ -206,6 +207,7 @@ func ParseHPAMetrics(hpa *autoscalingv2.HorizontalPodAutoscaler) ([]*MetricConfi
 			MetricTypeName:  typeName,
 			ObjectReference: ref,
 			Config:          map[string]string{},
+			MetricSpec:      metric,
 		}
 
 		if metric.Type == autoscalingv2.ExternalMetricSourceType &&


### PR DESCRIPTION
This adds support for `averageValue` for the `request-per-second` metric based on Ingress Objects. This is only supported from Kubernetes `>=v1.14` (https://github.com/kubernetes/kubernetes/pull/72872).

When defining the HPA with `autoscaling/v2beta1` you still need to define `targetValue` even though it won't be used when `averageValue` is set. Once we default to `autoscaling/v2beta2` this akward API will be gone.

This PR also enhances the README with Kubernetes compatibility expectations and a reference to supported Kubernetes versions for each collector type.