### PR TITLE
collector/prometheus: add Prometheus URL (optional) as an annotation in HPA

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,10 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: myapp-hpa
   annotations:
+    # This annotation is optional.
+    # If specified, then this prometheus server is used,
+    # instead of the prometheus server specified as the CLI argument `--prometheus-server`.
+    metric-config.external.prometheus-query.prometheus/prometheus-server: http://prometheus.my-namespace.svc
     # metric-config.<metricType>.<metricName>.<collectorName>/<configKey>
     # <configKey> == query-name
     metric-config.external.prometheus-query.prometheus/processed-events-per-second: |


### PR DESCRIPTION
# One-line summary

> Issue : #74 

## Description
In this PR I've added an option to specify a Prometheus URL in an API annotation, so it will override the one specified in CLI arguments. 

## Types of Changes
- New feature

## Tasks
None

## Review
None

## Deployment Notes
None
