### PR TITLE
Fix, use collector name to get plugin, not metric name

### DIFF
--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -134,7 +134,7 @@ func (c *CollectorFactory) NewCollector(hpa *autoscalingv2.HorizontalPodAutoscal
 			return c.objectPlugins.Any.Any.NewCollector(hpa, config, interval)
 		}
 	case autoscalingv2.ExternalMetricSourceType:
-		if plugin, ok := c.externalPlugins[config.Metric.Name]; ok {
+		if plugin, ok := c.externalPlugins[config.CollectorName]; ok {
 			return plugin.NewCollector(hpa, config, interval)
 		}
 	}


### PR DESCRIPTION
## Description
For external metrics was used metric name to get collector, but this does not correspond to documentation. In example configuration of prometheus is used collector name not metric name.

Other possibility is, the documentation is wrong (or i missed something :)

This MR demonstrates the problem, but brings backward incopatibile change! Serious thinking should be done before considering merging this. Mey-be another approach would be more appropriate (keep somehow bacward compatibility?).

## Types of Changes

- Bug fix (__breaking__ change which fixes an issue)

## Tasks
Verify original author intentions.

## Review
- [ ] Tests
- [ ] CHANGELOG

