### PR TITLE
Fix #89 by copying the MatchLabels map instead of referencing it.

### DIFF
--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -213,7 +213,9 @@ func ParseHPAMetrics(hpa *autoscalingv2.HorizontalPodAutoscaler) ([]*MetricConfi
 		if metric.Type == autoscalingv2.ExternalMetricSourceType &&
 			metric.External.Metric.Selector != nil &&
 			metric.External.Metric.Selector.MatchLabels != nil {
-			config.Config = metric.External.Metric.Selector.MatchLabels
+			for k, v := range metric.External.Metric.Selector.MatchLabels {
+				config.Config[k] = v
+			}
 		}
 
 		annotationConfigs, present := parser.GetAnnotationConfig(typeName.Metric.Name, typeName.Type)


### PR DESCRIPTION
Signed-off-by: Johann Fuechsl <johann@fuechsl.co>

# One-line summary

> Issue : #89 

## Description
Perform a copy of the MatchLabels map to the Config field of the metric config object for external metrics.

## Types of Changes
- Bug fix (non-breaking change which fixes an issue)

## Tasks
  - [x] Fix the bug as described in #89

## Review
_List of tasks the reviewer must do to review the PR_
- [ ] Tests
- [ ] Documentation
- [ ] CHANGELOG

## Deployment Notes
None
