### PR TITLE
Permit disregarding incompatible HPAs

### DIFF
--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -46,6 +46,14 @@ type CollectorPlugin interface {
 	NewCollector(hpa *autoscalingv2.HorizontalPodAutoscaler, config *MetricConfig, interval time.Duration) (Collector, error)
 }
 
+type PluginNotFoundError struct {
+	metricTypeName MetricTypeName
+}
+
+func (p *PluginNotFoundError) Error() string {
+	return fmt.Sprintf("no plugin found for %s", p.metricTypeName)
+}
+
 func (c *CollectorFactory) RegisterPodsCollector(metricCollector string, plugin CollectorPlugin) error {
 	if metricCollector == "" {
 		c.podsPlugins.Any = plugin
@@ -139,7 +147,7 @@ func (c *CollectorFactory) NewCollector(hpa *autoscalingv2.HorizontalPodAutoscal
 		}
 	}
 
-	return nil, fmt.Errorf("no plugin found for %s", config.MetricTypeName)
+	return nil, &PluginNotFoundError{metricTypeName: config.MetricTypeName}
 }
 
 type MetricTypeName struct {

--- a/pkg/provider/hpa.go
+++ b/pkg/provider/hpa.go
@@ -168,7 +168,8 @@ func (p *HPAProvider) updateHPAs() error {
 				c, err := p.collectorFactory.NewCollector(&hpa, config, interval)
 				if err != nil {
 
-					if errors.Is(err, &collector.PluginNotFoundError{}) && !p.disregardIncompatibleHPAs {
+					// Only log when it's not a PluginNotFoundError AND flag disregardIncompatibleHPAs is true
+					if !(errors.Is(err, &collector.PluginNotFoundError{}) && p.disregardIncompatibleHPAs) {
 						p.recorder.Eventf(&hpa, apiv1.EventTypeWarning, "CreateNewMetricsCollector", "Failed to create new metrics collector: %v", err)
 					}
 

--- a/pkg/provider/hpa_test.go
+++ b/pkg/provider/hpa_test.go
@@ -73,7 +73,7 @@ func TestUpdateHPAs(t *testing.T) {
 	err = collectorFactory.RegisterPodsCollector("", mockCollectorPlugin{})
 	require.NoError(t, err)
 
-	provider := NewHPAProvider(fakeClient, 1*time.Second, 1*time.Second, collectorFactory)
+	provider := NewHPAProvider(fakeClient, 1*time.Second, 1*time.Second, collectorFactory, false)
 	provider.collectorScheduler = NewCollectorScheduler(context.Background(), provider.metricSink)
 
 	err = provider.updateHPAs()

--- a/pkg/provider/hpa_test.go
+++ b/pkg/provider/hpa_test.go
@@ -90,3 +90,51 @@ func TestUpdateHPAs(t *testing.T) {
 
 	require.Len(t, provider.collectorScheduler.table, 1)
 }
+
+func TestUpdateHPAsDisregardingIncompatibleHPA(t *testing.T) {
+	// Test HPAProvider with disregardIncompatibleHPAs = true
+
+	value := resource.MustParse("1k")
+
+	hpa := &autoscalingv1.HorizontalPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "hpa1",
+			Namespace:   "default",
+			Annotations: map[string]string{},
+		},
+		Spec: autoscalingv1.HorizontalPodAutoscalerSpec{
+			ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
+				Kind:       "Deployment",
+				Name:       "app",
+				APIVersion: "apps/v1",
+			},
+			MinReplicas: &[]int32{1}[0],
+			MaxReplicas: 10,
+			Metrics: []autoscalingv1.MetricSpec{
+				{
+					Type: autoscalingv1.ExternalMetricSourceType,
+					External: &autoscalingv1.ExternalMetricSource{
+						MetricName:         "some-other-metric",
+						TargetAverageValue: &value,
+					},
+				},
+			},
+		},
+	}
+
+	fakeClient := fake.NewSimpleClientset()
+
+	var err error
+	_, err = fakeClient.AutoscalingV2beta1().HorizontalPodAutoscalers("default").Create(hpa)
+	require.NoError(t, err)
+
+	collectorFactory := collector.NewCollectorFactory()
+	err = collectorFactory.RegisterPodsCollector("", mockCollectorPlugin{})
+	require.NoError(t, err)
+
+	provider := NewHPAProvider(fakeClient, 1*time.Second, 1*time.Second, collectorFactory, true)
+	provider.collectorScheduler = NewCollectorScheduler(context.Background(), provider.metricSink)
+
+	err = provider.updateHPAs()
+	require.NoError(t, err)
+}

--- a/pkg/server/start.go
+++ b/pkg/server/start.go
@@ -105,7 +105,7 @@ func NewCommandStartAdapterServer(stopCh <-chan struct{}) *cobra.Command {
 	flags.StringSliceVar(&o.AWSRegions, "aws-region", o.AWSRegions, "the AWS regions which should be monitored. eg: eu-central, eu-west-1")
 	flags.StringVar(&o.MetricsAddress, "metrics-address", o.MetricsAddress, "The address where to serve prometheus metrics")
 	flags.BoolVar(&o.DisregardIncompatibleHPAs, "disregard-incompatible-hpas", o.DisregardIncompatibleHPAs, ""+
-		"whether to disregard failing to create collectors for incompatible HPAs")
+		"disregard failing to create collectors for incompatible HPAs")
 	return cmd
 }
 

--- a/pkg/server/start.go
+++ b/pkg/server/start.go
@@ -104,7 +104,8 @@ func NewCommandStartAdapterServer(stopCh <-chan struct{}) *cobra.Command {
 		"whether to enable AWS external metrics")
 	flags.StringSliceVar(&o.AWSRegions, "aws-region", o.AWSRegions, "the AWS regions which should be monitored. eg: eu-central, eu-west-1")
 	flags.StringVar(&o.MetricsAddress, "metrics-address", o.MetricsAddress, "The address where to serve prometheus metrics")
-
+	flags.BoolVar(&o.DisregardIncompatibleHPAs, "disregard-incompatible-hpas", o.DisregardIncompatibleHPAs, ""+
+		"whether to disregard failing to create collectors for incompatible HPAs")
 	return cmd
 }
 
@@ -214,7 +215,7 @@ func (o AdapterServerOptions) RunCustomMetricsAdapterServer(stopCh <-chan struct
 		collectorFactory.RegisterExternalCollector([]string{collector.AWSSQSQueueLengthMetric}, collector.NewAWSCollectorPlugin(awsSessions))
 	}
 
-	hpaProvider := provider.NewHPAProvider(client, 30*time.Second, 1*time.Minute, collectorFactory)
+	hpaProvider := provider.NewHPAProvider(client, 30*time.Second, 1*time.Minute, collectorFactory, o.DisregardIncompatibleHPAs)
 
 	go hpaProvider.Run(ctx)
 
@@ -312,4 +313,7 @@ type AdapterServerOptions struct {
 	MetricsAddress string
 	// SkipperBackendWeightAnnotation is the annotation on the ingress indicating the backend weights
 	SkipperBackendWeightAnnotation []string
+	// Whether to disregard failing to create collectors for incompatible HPAs - such as when using
+	// kube-metrics-adapter beside another Metrics Provider
+	DisregardIncompatibleHPAs bool
 }


### PR DESCRIPTION
# One-line summary
Permit disregarding incompatible HPAs.

> Issue : #94

## Description
This adds a `--disregard-incompatible-hpas` that makes the HPA provider stop erroring out when a collector cannot be created for a metric in a HPA. Useful when kube-metrics-adapter runs alongside another metrics provider. Fixes issue #94.

## Types of Changes
_What types of changes does your code introduce? Keep the ones that apply:_

- New feature (non-breaking change which adds functionality)
- Bug fix (non-breaking change which fixes an issue)
- Configuration change

## Tasks

## Review
_List of tasks the reviewer must do to review the PR_
- [ ] Tests
- [ ] Documentation
- [ ] CHANGELOG

## Deployment Notes
NA. The flag should assume the sensible Go zero value default of `false`.
