### PR TITLE
Reuse the HTTP client for scraping pods

### DIFF
--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"flag"
+	_ "net/http/pprof"
 	"os"
 	"runtime"
 

--- a/pkg/collector/json_path_collector_test.go
+++ b/pkg/collector/json_path_collector_test.go
@@ -7,6 +7,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func compareMetricsGetter(t *testing.T, first, second *JSONPathMetricsGetter) {
+	require.Equal(t, first.jsonPath, second.jsonPath)
+	require.Equal(t, first.scheme, second.scheme)
+	require.Equal(t, first.path, second.path)
+	require.Equal(t, first.port, second.port)
+}
+
 func TestNewJSONPathMetricsGetter(t *testing.T) {
 	configNoAggregator := map[string]string{
 		"json-key": "$.value",
@@ -18,7 +25,7 @@ func TestNewJSONPathMetricsGetter(t *testing.T) {
 	getterNoAggregator, err1 := NewJSONPathMetricsGetter(configNoAggregator)
 
 	require.NoError(t, err1)
-	require.Equal(t, &JSONPathMetricsGetter{
+	compareMetricsGetter(t, &JSONPathMetricsGetter{
 		jsonPath: jpath1,
 		scheme:   "http",
 		path:     "/metrics",
@@ -36,7 +43,7 @@ func TestNewJSONPathMetricsGetter(t *testing.T) {
 	getterAggregator, err2 := NewJSONPathMetricsGetter(configAggregator)
 
 	require.NoError(t, err2)
-	require.Equal(t, &JSONPathMetricsGetter{
+	compareMetricsGetter(t, &JSONPathMetricsGetter{
 		jsonPath:   jpath2,
 		scheme:     "http",
 		path:       "/metrics",

--- a/pkg/collector/pod_collector.go
+++ b/pkg/collector/pod_collector.go
@@ -2,6 +2,7 @@ package collector
 
 import (
 	"fmt"
+	"net/http"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -37,6 +38,7 @@ type PodCollector struct {
 	metricType       autoscalingv2.MetricSourceType
 	interval         time.Duration
 	logger           *log.Entry
+	httpClient       *http.Client
 }
 
 type PodMetricsGetter interface {


### PR DESCRIPTION
Currently a new `http.Client` is created whenever a pod metrics endpoint has to be scraped. This leaves idle connections lying around which piles up and causes a memory leak. By reusing the client and setting idle connection timeouts we can prevent this. 