### PR TITLE
fix(influxdb): fix swap of org/token

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,10 +369,11 @@ metadata:
     # instead of using the ones specified via CLI. Respectively:
     #  - --influxdb-address
     #  - --influxdb-token
-    #  - --influxdb-org-id
+    #  - --influxdb-org
     metric-config.external.flux-query.influxdb/address: "http://influxdbv2.my-namespace.svc"
     metric-config.external.flux-query.influxdb/token: "secret-token"
-    metric-config.external.flux-query.influxdb/org-id: "deadbeef"
+    # This could be either the organization name or the ID.
+    metric-config.external.flux-query.influxdb/org: "deadbeef"
     # metric-config.<metricType>.<metricName>.<collectorName>/<configKey>
     # <configKey> == query-name
     metric-config.external.flux-query.influxdb/queue_depth: |

--- a/pkg/collector/influxdb_collector_test.go
+++ b/pkg/collector/influxdb_collector_test.go
@@ -36,7 +36,7 @@ func TestInfluxDBCollector_New(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if got, want := c.orgID, "deadbeef"; want != got {
+		if got, want := c.org, "deadbeef"; want != got {
 			t.Errorf("unexpected value -want/+got:\n\t-%s\n\t+%s", want, got)
 		}
 		if got, want := c.address, "http://localhost:9999"; want != got {
@@ -69,7 +69,7 @@ func TestInfluxDBCollector_New(t *testing.T) {
 				"range3m":    `from(bucket: "?") |> range(start: -3m)`,
 				"address":    "http://localhost:9999",
 				"token":      "sEcr3TT0ken",
-				"org-id":     "deadbeef1234",
+				"org":        "deadbeef1234",
 				"query-name": "range3m",
 			},
 		}
@@ -77,7 +77,7 @@ func TestInfluxDBCollector_New(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if got, want := c.orgID, "deadbeef1234"; want != got {
+		if got, want := c.org, "deadbeef1234"; want != got {
 			t.Errorf("unexpected value -want/+got:\n\t-%s\n\t+%s", want, got)
 		}
 		if got, want := c.address, "http://localhost:9999"; want != got {

--- a/pkg/server/start.go
+++ b/pkg/server/start.go
@@ -92,7 +92,7 @@ func NewCommandStartAdapterServer(stopCh <-chan struct{}) *cobra.Command {
 		"address of InfluxDB 2.x server to query (e.g. http://localhost:9999)")
 	flags.StringVar(&o.InfluxDBToken, "influxdb-token", o.InfluxDBToken, ""+
 		"token for InfluxDB 2.x server to query")
-	flags.StringVar(&o.InfluxDBOrgID, "influxdb-org-id", o.InfluxDBOrgID, ""+
+	flags.StringVar(&o.InfluxDBOrg, "influxdb-org", o.InfluxDBOrg, ""+
 		"organization ID for InfluxDB 2.x server to query")
 	flags.StringVar(&o.ZMONKariosDBEndpoint, "zmon-kariosdb-endpoint", o.ZMONKariosDBEndpoint, ""+
 		"url of ZMON KariosDB endpoint to query for ZMON checks")
@@ -183,7 +183,7 @@ func (o AdapterServerOptions) RunCustomMetricsAdapterServer(stopCh <-chan struct
 	}
 
 	if o.InfluxDBAddress != "" {
-		influxdbPlugin, err := collector.NewInfluxDBCollectorPlugin(client, o.InfluxDBAddress, o.InfluxDBToken, o.InfluxDBOrgID)
+		influxdbPlugin, err := collector.NewInfluxDBCollectorPlugin(client, o.InfluxDBAddress, o.InfluxDBToken, o.InfluxDBOrg)
 		if err != nil {
 			return fmt.Errorf("failed to initialize InfluxDB collector plugin: %v", err)
 		}
@@ -309,8 +309,8 @@ type AdapterServerOptions struct {
 	InfluxDBAddress string
 	// InfluxDBToken is the token used for querying InfluxDB
 	InfluxDBToken string
-	// InfluxDBOrgID is the organization ID used for querying InfluxDB
-	InfluxDBOrgID string
+	// InfluxDBOrg is the organization ID used for querying InfluxDB
+	InfluxDBOrg string
 	// ZMONKariosDBEndpoint enables ZMON check queries to the specified
 	// kariosDB endpoint
 	ZMONKariosDBEndpoint string


### PR DESCRIPTION
## One line summary

Fix an error in passing parameters to InfluxDBCollector and convert to `org` instead of `orgID` (that's actually how InfluxDB treats that param, it could be the org name or ID).

## Description

Fixing that error would make it work 😅 

## Types of Changes
_What types of changes does your code introduce? Keep the ones that apply:_


- Bug fix (non-breaking change which fixes an issue)
- Refactor/improvements
- Documentation / non-code
