### PR TITLE
Add support for passing URL query params to pod metric endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,17 @@ values of JSONPath expressions that evaluate to arrays/slices of numbers.
 It's optional but when the expression evaluates to an array/slice, it's absence will
 produce an error. The supported aggregation functions are `avg`, `max`, `min` and `sum`.
 
+The `raw-query` configuration option specifies the query params to send along to the endpoint:
+```yaml
+  metric-config.pods.requests-per-second.json-path/path: /metrics
+  metric-config.pods.requests-per-second.json-path/port: "9090"
+  metric-config.pods.requests-per-second.json-path/raw-query: "foo=bar&baz=bop"
+```
+will create a URL like this:
+```
+http://<podIP>:9090/metrics?foo=bar&baz=bop
+```
+
 ## Prometheus collector
 
 The Prometheus collector is a generic collector which can map Prometheus

--- a/pkg/collector/json_path_collector_test.go
+++ b/pkg/collector/json_path_collector_test.go
@@ -1,6 +1,7 @@
 package collector
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/oliveagle/jsonpath"
@@ -70,6 +71,25 @@ func TestNewJSONPathMetricsGetter(t *testing.T) {
 
 	_, err4 := NewJSONPathMetricsGetter(configErrorPort)
 	require.Error(t, err4)
+
+	configWithRawQuery := map[string]string{
+		"json-key":  "$.values",
+		"scheme":    "http",
+		"path":      "/metrics",
+		"port":      "9090",
+		"raw-query": "foo=bar&baz=bop",
+	}
+	jpath5, _ := jsonpath.Compile(configWithRawQuery["json-key"])
+	getterWithRawQuery, err5 := NewJSONPathMetricsGetter(configWithRawQuery)
+
+	require.NoError(t, err5)
+	compareMetricsGetter(t, &JSONPathMetricsGetter{
+		jsonPath: jpath5,
+		scheme:   "http",
+		path:     "/metrics",
+		port:     9090,
+		rawQuery: "foo=bar&baz=bop",
+	}, getterWithRawQuery)
 }
 
 func TestCastSlice(t *testing.T) {
@@ -109,4 +129,45 @@ func TestReduce(t *testing.T) {
 
 	_, err5 := reduce([]float64{1, 2, 3}, "inexistent_function")
 	require.Errorf(t, err5, "slice of numbers was returned by JSONPath, but no valid aggregator function was specified: %v", "inexistent_function")
+}
+
+func TestBuildMetricsURL(t *testing.T) {
+	scheme := "http"
+	ip := "1.2.3.4"
+	port := "9090"
+	path := "/v1/test/"
+	rawQuery := "foo=bar&baz=bop"
+
+	// Test building URL with rawQuery
+	configWithRawQuery := map[string]string{
+		"json-key":  "$.value",
+		"scheme":    scheme,
+		"path":      path,
+		"port":      port,
+		"raw-query": rawQuery,
+	}
+	_, err := jsonpath.Compile(configWithRawQuery["json-key"])
+	require.NoError(t, err)
+	getterWithRawQuery, err1 := NewJSONPathMetricsGetter(configWithRawQuery)
+	require.NoError(t, err1)
+
+	expectedURLWithQuery := fmt.Sprintf("%s://%s:%s%s?%s", scheme, ip, port, path, rawQuery)
+	receivedURLWithQuery := getterWithRawQuery.buildMetricsURL(ip)
+	require.Equal(t, receivedURLWithQuery.String(), expectedURLWithQuery)
+
+	// Test building URL without rawQuery
+	configWithNoQuery := map[string]string{
+		"json-key": "$.value",
+		"scheme":   scheme,
+		"path":     path,
+		"port":     port,
+	}
+	_, err2 := jsonpath.Compile(configWithNoQuery["json-key"])
+	require.NoError(t, err2)
+	getterWithNoQuery, err3 := NewJSONPathMetricsGetter(configWithNoQuery)
+	require.NoError(t, err3)
+
+	expectedURLNoQuery := fmt.Sprintf("%s://%s:%s%s", scheme, ip, port, path)
+	receivedURLNoQuery := getterWithNoQuery.buildMetricsURL(ip)
+	require.Equal(t, receivedURLNoQuery.String(), expectedURLNoQuery)
 }


### PR DESCRIPTION
# One-line summary
Add support for passing URL query params to pod metric endpoints
Issue : #108 

## Description
Adds a new metric-config option named `raw-query`. The value of this option will be appended to the metric `path` as URL query parameters to be used by the pod's application.
E.g.,:
```
metric-config.pods.requests-per-second.json-path/raw-query: "foo=bar&baz=bop"
```
will append `?foo=bar&baz=bop` to the URL.

## Types of Changes
New feature (non-breaking change which adds functionality)

## Tasks
 - [x] Get all automated checks green
 - [x] Get PR reviewed

## Review
_List of tasks the reviewer must do to review the PR_
- [ ] Tests
- [ ] Documentation
- [ ] CHANGELOG
