### PR TITLE
fix error to not contain twice the namespace

### DIFF
--- a/pkg/collector/json_path_collector.go
+++ b/pkg/collector/json_path_collector.go
@@ -147,7 +147,7 @@ func castSlice(in []interface{}) ([]float64, error) {
 // getPodMetrics returns the content of the pods metrics endpoint.
 func (g *JSONPathMetricsGetter) getPodMetrics(pod *corev1.Pod) ([]byte, error) {
 	if pod.Status.PodIP == "" {
-		return nil, fmt.Errorf("pod %s/%s does not have a pod IP", pod.Namespace, pod.Namespace)
+		return nil, fmt.Errorf("pod %s/%s does not have a pod IP", pod.Namespace, pod.Name)
 	}
 
 	metricsURL := g.buildMetricsURL(pod.Status.PodIP)


### PR DESCRIPTION


# One-line summary
Error contains twice the namespace instead of name of the pod and namespace

> Issue : #1234 (only if appropriate)

## Description

fix

## Types of Changes
_What types of changes does your code introduce? Keep the ones that apply:_

- Bug fix (non-breaking change which fixes an issue)
- Documentation / non-code

