### PR TITLE
Add support for Ingress of API Group networking.k8s.io

### DIFF
--- a/pkg/collector/skipper_collector.go
+++ b/pkg/collector/skipper_collector.go
@@ -125,7 +125,7 @@ func getWeights(ingressAnnotations map[string]string, backendAnnotations []strin
 
 // getCollector returns a collector for getting the metrics.
 func (c *SkipperCollector) getCollector() (Collector, error) {
-	ingress, err := c.client.ExtensionsV1beta1().Ingresses(c.objectReference.Namespace).Get(c.objectReference.Name, metav1.GetOptions{})
+	ingress, err := c.client.NetworkingV1beta1().Ingresses(c.objectReference.Namespace).Get(c.objectReference.Name, metav1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/collector/skipper_collector_test.go
+++ b/pkg/collector/skipper_collector_test.go
@@ -10,7 +10,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv2 "k8s.io/api/autoscaling/v2beta2"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
+	v1beta1 "k8s.io/api/networking/v1beta1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -382,7 +382,7 @@ func makeIngress(client kubernetes.Interface, namespace, ingressName, backend st
 			Host: hostname,
 		})
 	}
-	_, err := client.ExtensionsV1beta1().Ingresses(namespace).Create(ingress)
+	_, err := client.NetworkingV1beta1().Ingresses(namespace).Create(ingress)
 	return err
 }
 

--- a/pkg/provider/metric_store.go
+++ b/pkg/provider/metric_store.go
@@ -69,9 +69,15 @@ func (s *MetricStore) insertCustomMetric(value custom_metrics.MetricValue) {
 			Resource: "pods",
 		}
 	case "Ingress":
+		// group can be either `extentions` or `networking.k8s.io`
+		group := "extensions"
+		gv, err := schema.ParseGroupVersion(value.DescribedObject.APIVersion)
+		if err == nil {
+			group = gv.Group
+		}
 		groupResource = schema.GroupResource{
 			Resource: "ingresses",
-			Group:    "extensions",
+			Group:    group,
 		}
 	}
 


### PR DESCRIPTION
This adds support for ingresses under `networking.k8s.io/v1beta1` such that there is a migration path for ingresses currently under `extensions/v1beta1` for metrics relying on the skipper collector.

It also changes the read api for ingresses to use `networking.k8s.io/v1beta1` this is available since Kubernetes v1.14 which is already the minimum version supported for the skipper collector.