### PR TITLE
Correctly treat ingress weight values as float64

### DIFF
--- a/pkg/collector/skipper_collector_test.go
+++ b/pkg/collector/skipper_collector_test.go
@@ -112,7 +112,7 @@ func TestSkipperCollector(t *testing.T) {
 		expectError        bool
 		fakedAverage       bool
 		namespace          string
-		backendWeights     map[string]map[string]int
+		backendWeights     map[string]map[string]float64
 		replicas           int32
 		readyReplicas      int32
 		backendAnnotations []string
@@ -138,7 +138,7 @@ func TestSkipperCollector(t *testing.T) {
 			collectedMetric:    1000,
 			namespace:          "default",
 			backend:            "backend1",
-			backendWeights:     map[string]map[string]int{testBackendWeightsAnnotation: {"backend2": 60, "backend1": 40}},
+			backendWeights:     map[string]map[string]float64{testBackendWeightsAnnotation: {"backend2": 60.0, "backend1": 40}},
 			replicas:           1,
 			readyReplicas:      1,
 			backendAnnotations: []string{testBackendWeightsAnnotation},
@@ -152,7 +152,7 @@ func TestSkipperCollector(t *testing.T) {
 			collectedMetric:    1000,
 			namespace:          "default",
 			backend:            "backend1",
-			backendWeights:     map[string]map[string]int{testBackendWeightsAnnotation: {"backend2": 60, "backend1": 40}},
+			backendWeights:     map[string]map[string]float64{testBackendWeightsAnnotation: {"backend2": 60, "backend1": 40}},
 			replicas:           1,
 			readyReplicas:      1,
 			backendAnnotations: []string{testBackendWeightsAnnotation},
@@ -167,7 +167,7 @@ func TestSkipperCollector(t *testing.T) {
 			fakedAverage:       true,
 			namespace:          "default",
 			backend:            "backend1",
-			backendWeights:     map[string]map[string]int{testBackendWeightsAnnotation: {"backend2": 50, "backend1": 50}},
+			backendWeights:     map[string]map[string]float64{testBackendWeightsAnnotation: {"backend2": 50, "backend1": 50}},
 			replicas:           5,
 			readyReplicas:      5,
 			backendAnnotations: []string{testBackendWeightsAnnotation},
@@ -181,7 +181,7 @@ func TestSkipperCollector(t *testing.T) {
 			collectedMetric:    1500,
 			namespace:          "default",
 			backend:            "backend1",
-			backendWeights:     map[string]map[string]int{testBackendWeightsAnnotation: {"backend2": 50, "backend1": 50}},
+			backendWeights:     map[string]map[string]float64{testBackendWeightsAnnotation: {"backend2": 50, "backend1": 50}},
 			replicas:           5, // this is not taken into account
 			readyReplicas:      5,
 			backendAnnotations: []string{testBackendWeightsAnnotation},
@@ -195,7 +195,7 @@ func TestSkipperCollector(t *testing.T) {
 			collectedMetric:    0,
 			namespace:          "default",
 			backend:            "backend1",
-			backendWeights:     map[string]map[string]int{testBackendWeightsAnnotation: {"backend2": 100, "backend1": 0}},
+			backendWeights:     map[string]map[string]float64{testBackendWeightsAnnotation: {"backend2": 100, "backend1": 0}},
 			replicas:           5,
 			readyReplicas:      5,
 			backendAnnotations: []string{testBackendWeightsAnnotation},
@@ -210,7 +210,7 @@ func TestSkipperCollector(t *testing.T) {
 			fakedAverage:    true,
 			namespace:       "default",
 			backend:         "backend1",
-			backendWeights: map[string]map[string]int{
+			backendWeights: map[string]map[string]float64{
 				testBackendWeightsAnnotation:  {"backend2": 20, "backend1": 80},
 				testStacksetWeightsAnnotation: {"backend2": 0, "backend1": 100},
 			},
@@ -227,7 +227,7 @@ func TestSkipperCollector(t *testing.T) {
 			collectedMetric: 1500,
 			namespace:       "default",
 			backend:         "backend1",
-			backendWeights: map[string]map[string]int{
+			backendWeights: map[string]map[string]float64{
 				testBackendWeightsAnnotation:  {"backend2": 20, "backend1": 80},
 				testStacksetWeightsAnnotation: {"backend2": 0, "backend1": 100},
 			},
@@ -244,7 +244,7 @@ func TestSkipperCollector(t *testing.T) {
 			collectedMetric:    0,
 			namespace:          "default",
 			backend:            "backend3",
-			backendWeights:     map[string]map[string]int{testBackendWeightsAnnotation: {"backend2": 100, "backend1": 0}},
+			backendWeights:     map[string]map[string]float64{testBackendWeightsAnnotation: {"backend2": 100, "backend1": 0}},
 			replicas:           1,
 			readyReplicas:      1,
 			backendAnnotations: []string{testBackendWeightsAnnotation},
@@ -258,7 +258,7 @@ func TestSkipperCollector(t *testing.T) {
 			collectedMetric:    1500,
 			namespace:          "default",
 			backend:            "backend3",
-			backendWeights:     map[string]map[string]int{},
+			backendWeights:     map[string]map[string]float64{},
 			replicas:           1,
 			readyReplicas:      1,
 			backendAnnotations: []string{testBackendWeightsAnnotation},
@@ -272,7 +272,7 @@ func TestSkipperCollector(t *testing.T) {
 			expectError:        true,
 			namespace:          "default",
 			backend:            "",
-			backendWeights:     map[string]map[string]int{testBackendWeightsAnnotation: {"backend2": 100, "backend1": 0}},
+			backendWeights:     map[string]map[string]float64{testBackendWeightsAnnotation: {"backend2": 100, "backend1": 0}},
 			replicas:           1,
 			readyReplicas:      1,
 			backendAnnotations: []string{testBackendWeightsAnnotation},
@@ -301,7 +301,7 @@ func TestSkipperCollector(t *testing.T) {
 			fakedAverage:    true,
 			namespace:       "default",
 			backend:         "backend2",
-			backendWeights: map[string]map[string]int{
+			backendWeights: map[string]map[string]float64{
 				testBackendWeightsAnnotation:  {"backend2": 20, "backend1": 80},
 				testStacksetWeightsAnnotation: {"backend1": 100},
 			},
@@ -314,12 +314,12 @@ func TestSkipperCollector(t *testing.T) {
 			metric:          1500,
 			ingressName:     "dummy-ingress",
 			hostnames:       []string{"example.org"},
-			expectedQuery:   `scalar(sum(rate(skipper_serve_host_duration_seconds_count{host=~"example_org"}[1m])) * 0.2000)`,
+			expectedQuery:   `scalar(sum(rate(skipper_serve_host_duration_seconds_count{host=~"example_org"}[1m])) * 0.2050)`,
 			collectedMetric: 1500,
 			namespace:       "default",
 			backend:         "backend2",
-			backendWeights: map[string]map[string]int{
-				testBackendWeightsAnnotation:  {"backend2": 20, "backend1": 80},
+			backendWeights: map[string]map[string]float64{
+				testBackendWeightsAnnotation:  {"backend2": 20.5, "backend1": 79.5},
 				testStacksetWeightsAnnotation: {"backend1": 100},
 			},
 			replicas:           5,
@@ -352,7 +352,7 @@ func TestSkipperCollector(t *testing.T) {
 	}
 }
 
-func makeIngress(client kubernetes.Interface, namespace, ingressName, backend string, hostnames []string, backendWeights map[string]map[string]int) error {
+func makeIngress(client kubernetes.Interface, namespace, ingressName, backend string, hostnames []string, backendWeights map[string]map[string]float64) error {
 	annotations := make(map[string]string)
 	for anno, weights := range backendWeights {
 		sWeights, err := json.Marshal(weights)


### PR DESCRIPTION
The value of `zalado.org/backend-weights` annotation on an ingress is defined as `map[string]float64` in most places e.g skipper and stackset-controller. 
Before we parsed it as `map[string]int` which would not work if a weight was defined e.g. as `100.0` as it would result in the following error: `json: cannot unmarshal number 100.0 into Go value of type int`.

For most cases this was actually not a problem as we mostly use whole numbers and go will marshal a `float64` like `100.0` into the string representation `100` which can be unmarshaled into an `int`.
However for some ingresses the values are represented as `100.0` and this would fail.

* This changes both the type from `int` -> `float64` and properly handles any json parsing errors so such issues wouldn't be swallowed without a clear reason in the future.
* Changes a test case to use decimal numbers to validate the parsing of floats.
