### PR TITLE
Fix handling of invalid/empty json response

### DIFF
--- a/pkg/collector/httpmetrics/json_path.go
+++ b/pkg/collector/httpmetrics/json_path.go
@@ -72,7 +72,7 @@ func (g *JSONPathMetricsGetter) GetMetric(metricsURL url.URL) (float64, error) {
 		return 0, err
 	}
 
-	if len(nodes) > 1 {
+	if len(nodes) != 1 {
 		return 0, fmt.Errorf("unexpected json: expected single numeric or array value")
 	}
 


### PR DESCRIPTION
Follow up to #192 fix handling of a json response where the jsonPath doesn't result in an Array or Number. I.e. the jsonPath is misconfigured or the response is unexpected format.

Prevents the controller from crashing with:

```
panic: runtime error: index out of range [0] with length 0
```