### PR TITLE
Use labels for mapping metric types to metrics

### DIFF
--- a/example/deploy/hpa.yaml
+++ b/example/deploy/hpa.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     application: custom-metrics-consumer
   annotations:
-    # metric-config.<metricType>.<metricName>.<collectorName>/<configKey>
+    # metric-config.<metricType>.<metricName>.<collectorType>/<configKey>
     metric-config.pods.queue-length.json-path/json-key: "$.queue.length"
     metric-config.pods.queue-length.json-path/path: /metrics
     metric-config.pods.queue-length.json-path/port: "9090"
@@ -50,9 +50,10 @@ spec:
   - type: External
     external:
       metric:
-        name: sqs-queue-length
+        name: app-queue-length
         selector:
           matchLabels:
+            type: sqs-queue-length
             queue-name: foobar
             region: eu-central-1
       target:

--- a/pkg/annotations/parser.go
+++ b/pkg/annotations/parser.go
@@ -15,7 +15,7 @@ const (
 )
 
 type AnnotationConfigs struct {
-	CollectorName string
+	CollectorType string
 	Configs       map[string]string
 	PerReplica    bool
 	Interval      time.Duration
@@ -64,14 +64,14 @@ func (m AnnotationConfigMap) Parse(annotations map[string]string) error {
 		config, ok := m[key]
 		if !ok {
 			config = &AnnotationConfigs{
-				CollectorName: metricCollector,
+				CollectorType: metricCollector,
 				Configs:       map[string]string{},
 			}
 			m[key] = config
 		}
 
 		// TODO: fail if collector name doesn't match
-		if config.CollectorName != metricCollector {
+		if config.CollectorType != metricCollector {
 			continue
 		}
 

--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -156,7 +156,9 @@ func (c *CollectorFactory) NewCollector(hpa *autoscalingv2.HorizontalPodAutoscal
 			if typ, ok := config.Metric.Selector.MatchLabels[typeLabelKey]; ok {
 				pluginKey = typ
 			}
-		} else {
+		}
+
+		if pluginKey == "" {
 			pluginKey = config.Metric.Name
 			c.logger.Warnf("HPA %s/%s is using deprecated metric type identifier '%s'", hpa.Namespace, hpa.Name, config.Metric.Name)
 		}

--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	log "github.com/sirupsen/logrus"
 	"github.com/zalando-incubator/kube-metrics-adapter/pkg/annotations"
 	autoscalingv2 "k8s.io/api/autoscaling/v2beta2"
 	"k8s.io/metrics/pkg/apis/custom_metrics"
@@ -23,6 +24,7 @@ type CollectorFactory struct {
 	podsPlugins     pluginMap
 	objectPlugins   objectPluginMap
 	externalPlugins map[string]CollectorPlugin
+	logger          *log.Entry
 }
 
 type objectPluginMap struct {
@@ -43,6 +45,7 @@ func NewCollectorFactory() *CollectorFactory {
 			Named: map[string]*pluginMap{},
 		},
 		externalPlugins: map[string]CollectorPlugin{},
+		logger:          log.WithFields(log.Fields{"collector": "true"}),
 	}
 }
 
@@ -155,6 +158,7 @@ func (c *CollectorFactory) NewCollector(hpa *autoscalingv2.HorizontalPodAutoscal
 			}
 		} else {
 			pluginKey = config.Metric.Name
+			c.logger.Warnf("HPA %s/%s is using deprecated metric type identifier '%s'", hpa.Namespace, hpa.Name, config.Metric.Name)
 		}
 
 		if plugin, ok := c.externalPlugins[pluginKey]; ok {

--- a/pkg/collector/collector_test.go
+++ b/pkg/collector/collector_test.go
@@ -1,0 +1,129 @@
+package collector
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	autoscalingv2 "k8s.io/api/autoscaling/v2beta2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type mockCollectorPlugin struct {
+	Name string
+}
+
+func (c *mockCollectorPlugin) NewCollector(hpa *autoscalingv2.HorizontalPodAutoscaler, config *MetricConfig, interval time.Duration) (Collector, error) {
+	return &mockCollector{Name: c.Name}, nil
+}
+
+type mockCollector struct {
+	Name string
+}
+
+func (c *mockCollector) GetMetrics() ([]CollectedMetric, error) {
+	return nil, nil
+}
+
+func (c *mockCollector) Interval() time.Duration {
+	return 0
+}
+
+func TestNewCollector(t *testing.T) {
+	for _, tc := range []struct {
+		msg               string
+		hpa               *autoscalingv2.HorizontalPodAutoscaler
+		expectedCollector string
+	}{
+		{
+			msg: "should get create collector type from legacy metric name",
+			hpa: &autoscalingv2.HorizontalPodAutoscaler{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{},
+				},
+				Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+					Metrics: []autoscalingv2.MetricSpec{
+						{
+							Type: autoscalingv2.ExternalMetricSourceType,
+							External: &autoscalingv2.ExternalMetricSource{
+								Metric: autoscalingv2.MetricIdentifier{
+									Name: "external-1",
+									Selector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{"x": "y"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedCollector: "external-1",
+		},
+		{
+			msg: "should get create collector type from type label (ignore legacy metric name)",
+			hpa: &autoscalingv2.HorizontalPodAutoscaler{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{},
+				},
+				Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+					Metrics: []autoscalingv2.MetricSpec{
+						{
+							Type: autoscalingv2.ExternalMetricSourceType,
+							External: &autoscalingv2.ExternalMetricSource{
+								Metric: autoscalingv2.MetricIdentifier{
+									Name: "external-1",
+									Selector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{"type": "external-2"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedCollector: "external-2",
+		},
+		{
+			msg: "should not find collector when no collector matches",
+			hpa: &autoscalingv2.HorizontalPodAutoscaler{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{},
+				},
+				Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+					Metrics: []autoscalingv2.MetricSpec{
+						{
+							Type: autoscalingv2.ExternalMetricSourceType,
+							External: &autoscalingv2.ExternalMetricSource{
+								Metric: autoscalingv2.MetricIdentifier{
+									Name: "external-3",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedCollector: "",
+		},
+	} {
+		t.Run(tc.msg, func(t *testing.T) {
+			collectorFactory := NewCollectorFactory()
+			for _, collector := range []string{"1", "2"} {
+				collectorFactory.RegisterExternalCollector([]string{"external-" + collector}, &mockCollectorPlugin{Name: "external-" + collector})
+			}
+			configs, err := ParseHPAMetrics(tc.hpa)
+			require.NoError(t, err)
+			require.Len(t, configs, 1)
+
+			collector, err := collectorFactory.NewCollector(tc.hpa, configs[0], 0)
+			if tc.expectedCollector == "" {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+
+				c, ok := collector.(*mockCollector)
+				require.True(t, ok)
+				require.Equal(t, tc.expectedCollector, c.Name)
+			}
+		})
+	}
+}

--- a/pkg/collector/http_collector.go
+++ b/pkg/collector/http_collector.go
@@ -14,7 +14,8 @@ import (
 )
 
 const (
-	HTTPMetricName            = "http"
+	HTTPJSONPathType          = "json-path"
+	HTTPMetricNameLegacy      = "http"
 	HTTPEndpointAnnotationKey = "endpoint"
 	HTTPJsonPathAnnotationKey = "json-key"
 	identifierLabel           = "identifier"

--- a/pkg/collector/influxdb_collector.go
+++ b/pkg/collector/influxdb_collector.go
@@ -15,7 +15,8 @@ import (
 )
 
 const (
-	InfluxDBMetricName        = "flux-query"
+	InfluxDBMetricType        = "influxdb"
+	InfluxDBMetricNameLegacy  = "flux-query"
 	influxDBAddressKey        = "address"
 	influxDBTokenKey          = "token"
 	influxDBOrgKey            = "org"

--- a/pkg/collector/influxdb_collector_test.go
+++ b/pkg/collector/influxdb_collector_test.go
@@ -24,7 +24,7 @@ func TestInfluxDBCollector_New(t *testing.T) {
 					},
 				},
 			},
-			CollectorName: "influxdb",
+			CollectorType: "influxdb",
 			Config: map[string]string{
 				"range1m":    `from(bucket: "?") |> range(start: -1m)`,
 				"range2m":    `from(bucket: "?") |> range(start: -2m)`,
@@ -62,7 +62,7 @@ func TestInfluxDBCollector_New(t *testing.T) {
 					},
 				},
 			},
-			CollectorName: "influxdb",
+			CollectorType: "influxdb",
 			Config: map[string]string{
 				"range1m":    `from(bucket: "?") |> range(start: -1m)`,
 				"range2m":    `from(bucket: "?") |> range(start: -2m)`,
@@ -140,7 +140,7 @@ func TestInfluxDBCollector_New(t *testing.T) {
 		t.Run("error - "+tc.name, func(t *testing.T) {
 			m := &MetricConfig{
 				MetricTypeName: tc.mTypeName,
-				CollectorName:  "influxdb",
+				CollectorType:  "influxdb",
 				Config:         tc.config,
 			}
 			_, err := NewInfluxDBCollector("http://localhost:9999", "secret", "deadbeef", m, time.Second)

--- a/pkg/collector/pod_collector.go
+++ b/pkg/collector/pod_collector.go
@@ -61,7 +61,7 @@ func NewPodCollector(client kubernetes.Interface, hpa *autoscalingv2.HorizontalP
 	}
 
 	var getter httpmetrics.PodMetricsGetter
-	switch config.CollectorName {
+	switch config.CollectorType {
 	case "json-path":
 		var err error
 		getter, err = httpmetrics.NewPodMetricsJSONPathGetter(config.Config)
@@ -69,7 +69,7 @@ func NewPodCollector(client kubernetes.Interface, hpa *autoscalingv2.HorizontalP
 			return nil, err
 		}
 	default:
-		return nil, fmt.Errorf("format '%s' not supported", config.CollectorName)
+		return nil, fmt.Errorf("format '%s' not supported", config.CollectorType)
 	}
 
 	c.Getter = getter

--- a/pkg/collector/pod_collector_test.go
+++ b/pkg/collector/pod_collector_test.go
@@ -97,7 +97,7 @@ func makeTestHTTPServer(t *testing.T, values [][]int64) (string, string, *testMe
 
 func makeTestConfig(port string) *MetricConfig {
 	return &MetricConfig{
-		CollectorName: "json-path",
+		CollectorType: "json-path",
 		Config:        map[string]string{"json-key": "$.values", "port": port, "path": "/metrics", "aggregator": "sum"},
 	}
 }

--- a/pkg/collector/prometheus_collector.go
+++ b/pkg/collector/prometheus_collector.go
@@ -19,7 +19,8 @@ import (
 )
 
 const (
-	PrometheusMetricName          = "prometheus-query"
+	PrometheusMetricType          = "prometheus"
+	PrometheusMetricNameLegacy    = "prometheus-query"
 	prometheusQueryNameLabelKey   = "query-name"
 	prometheusServerAnnotationKey = "prometheus-server"
 )

--- a/pkg/collector/zmon_collector.go
+++ b/pkg/collector/zmon_collector.go
@@ -14,9 +14,10 @@ import (
 )
 
 const (
-	// ZMONCheckMetric defines the metric name for metrics based on ZMON
+	// ZMONMetricType defines the metric type for metrics based on ZMON
 	// checks.
-	ZMONCheckMetric            = "zmon-check"
+	ZMONMetricType             = "zmon"
+	ZMONCheckMetricLegacy      = "zmon-check"
 	zmonCheckIDLabelKey        = "check-id"
 	zmonKeyLabelKey            = "key"
 	zmonDurationLabelKey       = "duration"
@@ -42,12 +43,7 @@ func NewZMONCollectorPlugin(zmon zmon.ZMON) (*ZMONCollectorPlugin, error) {
 
 // NewCollector initializes a new ZMON collector from the specified HPA.
 func (c *ZMONCollectorPlugin) NewCollector(hpa *autoscalingv2.HorizontalPodAutoscaler, config *MetricConfig, interval time.Duration) (Collector, error) {
-	switch config.Metric.Name {
-	case ZMONCheckMetric:
-		return NewZMONCollector(c.zmon, config, interval)
-	}
-
-	return nil, fmt.Errorf("metric '%s' not supported", config.Metric.Name)
+	return NewZMONCollector(c.zmon, config, interval)
 }
 
 // ZMONCollector defines a collector that is able to collect metrics from ZMON.

--- a/pkg/collector/zmon_collector_test.go
+++ b/pkg/collector/zmon_collector_test.go
@@ -26,7 +26,7 @@ func TestZMONCollectorNewCollector(t *testing.T) {
 
 	config := &MetricConfig{
 		MetricTypeName: MetricTypeName{
-			Metric: newMetricIdentifier(ZMONCheckMetric),
+			Metric: newMetricIdentifier("foo-check", ZMONMetricType),
 		},
 		Config: map[string]string{
 			zmonCheckIDLabelKey:             "1234",
@@ -50,28 +50,26 @@ func TestZMONCollectorNewCollector(t *testing.T) {
 	require.Equal(t, []string{"max"}, zmonCollector.aggregators)
 	require.Equal(t, map[string]string{"alias": "cluster_alias"}, zmonCollector.tags)
 
-	// should fail if the metric name isn't ZMON
-	config.Metric = newMetricIdentifier("non-zmon-check")
-	_, err = collectPlugin.NewCollector(nil, config, 1*time.Second)
-	require.Error(t, err)
-
 	// should fail if the check id is not specified.
 	delete(config.Config, zmonCheckIDLabelKey)
-	config.Metric.Name = ZMONCheckMetric
+	config.Metric.Name = "foo-check"
 	_, err = collectPlugin.NewCollector(nil, config, 1*time.Second)
 	require.Error(t, err)
 }
 
-func newMetricIdentifier(metricName string) autoscalingv2.MetricIdentifier {
-	selector := metav1.LabelSelector{}
+func newMetricIdentifier(metricName, metricType string) autoscalingv2.MetricIdentifier {
+	selector := metav1.LabelSelector{
+		MatchLabels: map[string]string{
+			"type": metricType,
+		},
+	}
 	return autoscalingv2.MetricIdentifier{Name: metricName, Selector: &selector}
 }
 
 func TestZMONCollectorGetMetrics(tt *testing.T) {
-
 	config := &MetricConfig{
 		MetricTypeName: MetricTypeName{
-			Metric: newMetricIdentifier(ZMONCheckMetric),
+			Metric: newMetricIdentifier("foo-check", ZMONMetricType),
 			Type:   "foo",
 		},
 		Config: map[string]string{

--- a/pkg/server/start.go
+++ b/pkg/server/start.go
@@ -174,7 +174,7 @@ func (o AdapterServerOptions) RunCustomMetricsAdapterServer(stopCh <-chan struct
 			return fmt.Errorf("failed to register prometheus object collector plugin: %v", err)
 		}
 
-		collectorFactory.RegisterExternalCollector([]string{collector.PrometheusMetricName}, promPlugin)
+		collectorFactory.RegisterExternalCollector([]string{collector.PrometheusMetricType, collector.PrometheusMetricNameLegacy}, promPlugin)
 
 		// skipper collector can only be enabled if prometheus is.
 		if o.SkipperIngressMetrics {
@@ -195,11 +195,11 @@ func (o AdapterServerOptions) RunCustomMetricsAdapterServer(stopCh <-chan struct
 		if err != nil {
 			return fmt.Errorf("failed to initialize InfluxDB collector plugin: %v", err)
 		}
-		collectorFactory.RegisterExternalCollector([]string{collector.InfluxDBMetricName}, influxdbPlugin)
+		collectorFactory.RegisterExternalCollector([]string{collector.InfluxDBMetricType, collector.InfluxDBMetricNameLegacy}, influxdbPlugin)
 	}
 
 	plugin, _ := collector.NewHTTPCollectorPlugin()
-	collectorFactory.RegisterExternalCollector([]string{collector.HTTPMetricName}, plugin)
+	collectorFactory.RegisterExternalCollector([]string{collector.HTTPJSONPathType, collector.HTTPMetricNameLegacy}, plugin)
 	// register generic pod collector
 	err = collectorFactory.RegisterPodsCollector("", collector.NewPodCollectorPlugin(client))
 	if err != nil {
@@ -224,7 +224,7 @@ func (o AdapterServerOptions) RunCustomMetricsAdapterServer(stopCh <-chan struct
 			return fmt.Errorf("failed to initialize ZMON collector plugin: %v", err)
 		}
 
-		collectorFactory.RegisterExternalCollector([]string{collector.ZMONCheckMetric}, zmonPlugin)
+		collectorFactory.RegisterExternalCollector([]string{collector.ZMONMetricType, collector.ZMONCheckMetricLegacy}, zmonPlugin)
 	}
 
 	awsSessions := make(map[string]*session.Session, len(o.AWSRegions))


### PR DESCRIPTION
For historical reasons (i.e. use of previous autoscaling API versions) we have been mapping **metric names** to the different collector types. I.e. if you wanted a metric based on `prometheus` you would name the metric `prometheus-query`.
This design has the downside that multiple metrics will have the same name and it becomes hard to distinguish as reported in #104 
In some cases it can even prevent having more than a single metric of a certain type i.e. if you use the `zmon-check` metric and have the same `check-id` but different complex keys defined (complex keys must be defined as annotation, and this will overlap if you have more than a single zmon-check metric defined).

It was initially done because we didn't have any other identifiers in the HPA spec, at least for custom metrics, and this limitation was accidentally carried over for External metrics even though they have labels which can be used for such extra information. With `v2beta2` we have selector/labels for all the metric types and this can then be used to store this information.

This PR introduces support for multiple metrics of the same type by adding a convention of a `type` label on the metrics e.g. `type: prometheus` which is used to identify which collector type should be used.

I have also aligned some of the naming for the types so they are more simple i.e. `prometheus-query` becomes type `prometheus`.

To provide backwards compatibility the old metric names are still supported, but marked as *legacy* so we eventually can deprecate and remove them.

Fix #104