### PR TITLE
UPDATED to use NewSessionWithConfig instead of NewSession

### DIFF
--- a/pkg/server/start.go
+++ b/pkg/server/start.go
@@ -229,7 +229,11 @@ func (o AdapterServerOptions) RunCustomMetricsAdapterServer(stopCh <-chan struct
 
 	awsSessions := make(map[string]*session.Session, len(o.AWSRegions))
 	for _, region := range o.AWSRegions {
-		awsSessions[region], err = session.NewSession(&aws.Config{Region: aws.String(region)})
+		awsSessions[region], err = session.NewSessionWithOptions(session.Options{
+			Config: aws.Config{
+				Region: aws.String(region),
+			},
+		})
 		if err != nil {
 			return fmt.Errorf("unabled to create aws session for region: %s", region)
 		}


### PR DESCRIPTION
NewSession is being deprecated, NewSessionWithConfig handles things
such as role arns. This fixes permissions issues for users using
role arns for service accounts.

# One-line summary
Updated to use the suggested session constructor for AWS sessions. Which fixes certain AWS config values not being read at run time.

## Description
We noticed our HPA's were failing to scale on SQS message length metrics, on closer inspect the metrics adapter wasn't picking up our service accounts IAM_ROLE. This was because the sessions were being instantiated using `NewSession` which for whatever reason doesn't pick up role arn automatically. It's suggested by AWS to use the new `NewSessionWithConfig` constructor instead, which attempts to load configurations from multiple sources. See: https://github.com/aws/aws-sdk-go/issues/3101 


## Types of Changes
_What types of changes does your code introduce? Keep the ones that apply:_
- Configuration change
- Refactor/improvements

## Deployment Notes
N/a