### PR TITLE
Switch to compliant base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.opensource.zalan.do/stups/alpine:latest
+FROM registry.opensource.zalan.do/library/alpine-3.12:latest
 MAINTAINER Team Teapot @ Zalando SE <team-teapot@zalando.de>
 
 # add binary


### PR DESCRIPTION
Use compliant base image according to our tech rules of play:
- KDP-1: use an approved Docker base image and version from the list of
    allowed Docker Base Images under the pierone namespace ‘library’.