### PR TITLE
Don't check for metric name on AWS init

### DIFF
--- a/pkg/collector/aws_collector.go
+++ b/pkg/collector/aws_collector.go
@@ -33,12 +33,7 @@ func NewAWSCollectorPlugin(sessions map[string]*session.Session) *AWSCollectorPl
 
 // NewCollector initializes a new skipper collector from the specified HPA.
 func (c *AWSCollectorPlugin) NewCollector(hpa *autoscalingv2.HorizontalPodAutoscaler, config *MetricConfig, interval time.Duration) (Collector, error) {
-	switch config.Metric.Name {
-	case AWSSQSQueueLengthMetric:
-		return NewAWSSQSCollector(c.sessions, config, interval)
-	}
-
-	return nil, fmt.Errorf("metric '%s' not supported", config.Metric.Name)
+	return NewAWSSQSCollector(c.sessions, config, interval)
 }
 
 type AWSSQSCollector struct {


### PR DESCRIPTION
Fixes an issue where the AWS SQS collector could not be correctly setup when the metric name was anything but `sqs-queue-length` even though it should be possible since #219

Removes the unneeded/invalid check from the AWS collector initialization.

Fix #239 