### PR TITLE
Fix the namespace of horizontal-pod-autoscaler service account used in the helm chart

### DIFF
--- a/docs/helm/templates/rbac.yaml
+++ b/docs/helm/templates/rbac.yaml
@@ -85,7 +85,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: horizontal-pod-autoscaler
-  namespace: {{ .Values.namespace }}
+  namespace: kube-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -98,7 +98,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: horizontal-pod-autoscaler
-  namespace: {{ .Values.namespace }}
+  namespace: kube-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
# Fixes the namespace of horizontal-pod-autoscaler service account used in the helm chart.

> Issue : #252

## Description
The incident reported in #252 occurs because cluster role bindings use wrong namespace for `horizontal-pod-autoscaler` service account. They get the namespace from `{{ .Values.namespace }}` expression which has a value other than `kube-system`.

This PR fixes that issue by setting the namespace for `horizontal-pod-autoscaler` service account as `kube-system`.

## Types of Changes
- Bug fix (non-breaking change which fixes an issue)

## Deployment Notes
Steps provided in #252 can be used to test this issue.
