### PR TITLE
Namespace external metrics

### DIFF
--- a/pkg/collector/aws_collector.go
+++ b/pkg/collector/aws_collector.go
@@ -33,7 +33,7 @@ func NewAWSCollectorPlugin(sessions map[string]*session.Session) *AWSCollectorPl
 
 // NewCollector initializes a new skipper collector from the specified HPA.
 func (c *AWSCollectorPlugin) NewCollector(hpa *autoscalingv2.HorizontalPodAutoscaler, config *MetricConfig, interval time.Duration) (Collector, error) {
-	return NewAWSSQSCollector(c.sessions, config, interval)
+	return NewAWSSQSCollector(c.sessions, hpa, config, interval)
 }
 
 type AWSSQSCollector struct {
@@ -42,11 +42,12 @@ type AWSSQSCollector struct {
 	region     string
 	queueURL   string
 	queueName  string
+	namespace  string
 	metric     autoscalingv2.MetricIdentifier
 	metricType autoscalingv2.MetricSourceType
 }
 
-func NewAWSSQSCollector(sessions map[string]*session.Session, config *MetricConfig, interval time.Duration) (*AWSSQSCollector, error) {
+func NewAWSSQSCollector(sessions map[string]*session.Session, hpa *autoscalingv2.HorizontalPodAutoscaler, config *MetricConfig, interval time.Duration) (*AWSSQSCollector, error) {
 	if config.Metric.Selector == nil {
 		return nil, fmt.Errorf("selector for queue is not specified")
 	}
@@ -80,6 +81,7 @@ func NewAWSSQSCollector(sessions map[string]*session.Session, config *MetricConf
 		interval:   interval,
 		queueURL:   aws.StringValue(resp.QueueUrl),
 		queueName:  name,
+		namespace:  hpa.Namespace,
 		metric:     config.Metric,
 		metricType: config.Type,
 	}, nil
@@ -103,7 +105,8 @@ func (c *AWSSQSCollector) GetMetrics() ([]CollectedMetric, error) {
 		}
 
 		metricValue := CollectedMetric{
-			Type: c.metricType,
+			Namespace: c.namespace,
+			Type:      c.metricType,
 			External: external_metrics.ExternalMetricValue{
 				MetricName:   c.metric.Name,
 				MetricLabels: c.metric.Selector.MatchLabels,

--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -177,9 +177,10 @@ type MetricTypeName struct {
 }
 
 type CollectedMetric struct {
-	Type     autoscalingv2.MetricSourceType
-	Custom   custom_metrics.MetricValue
-	External external_metrics.ExternalMetricValue
+	Type      autoscalingv2.MetricSourceType
+	Namespace string
+	Custom    custom_metrics.MetricValue
+	External  external_metrics.ExternalMetricValue
 }
 
 type Collector interface {

--- a/pkg/collector/http_collector_test.go
+++ b/pkg/collector/http_collector_test.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"k8s.io/api/autoscaling/v2beta2"
+	autoscalingv2 "k8s.io/api/autoscaling/v2beta2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -60,7 +62,12 @@ func TestHTTPCollector(t *testing.T) {
 			plugin, err := NewHTTPCollectorPlugin()
 			require.NoError(t, err)
 			testConfig := makeTestHTTPCollectorConfig(testServer, tc.aggregator)
-			collector, err := plugin.NewCollector(nil, testConfig, testInterval)
+			hpa := &autoscalingv2.HorizontalPodAutoscaler{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+				},
+			}
+			collector, err := plugin.NewCollector(hpa, testConfig, testInterval)
 			require.NoError(t, err)
 			metrics, err := collector.GetMetrics()
 			require.NoError(t, err)

--- a/pkg/collector/influxdb_collector_test.go
+++ b/pkg/collector/influxdb_collector_test.go
@@ -6,10 +6,17 @@ import (
 	"time"
 
 	"k8s.io/api/autoscaling/v2beta2"
+	autoscalingv2 "k8s.io/api/autoscaling/v2beta2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestInfluxDBCollector_New(t *testing.T) {
+	hpa := &autoscalingv2.HorizontalPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+		},
+	}
 	t.Run("simple", func(t *testing.T) {
 		m := &MetricConfig{
 			MetricTypeName: MetricTypeName{
@@ -32,7 +39,7 @@ func TestInfluxDBCollector_New(t *testing.T) {
 				"query-name": "range2m",
 			},
 		}
-		c, err := NewInfluxDBCollector("http://localhost:9999", "secret", "deadbeef", m, time.Second)
+		c, err := NewInfluxDBCollector(hpa, "http://localhost:9999", "secret", "deadbeef", m, time.Second)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -73,7 +80,7 @@ func TestInfluxDBCollector_New(t *testing.T) {
 				"query-name": "range3m",
 			},
 		}
-		c, err := NewInfluxDBCollector("http://localhost:8888", "secret", "deadbeef", m, time.Second)
+		c, err := NewInfluxDBCollector(hpa, "http://localhost:8888", "secret", "deadbeef", m, time.Second)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -143,7 +150,7 @@ func TestInfluxDBCollector_New(t *testing.T) {
 				CollectorType:  "influxdb",
 				Config:         tc.config,
 			}
-			_, err := NewInfluxDBCollector("http://localhost:9999", "secret", "deadbeef", m, time.Second)
+			_, err := NewInfluxDBCollector(hpa, "http://localhost:9999", "secret", "deadbeef", m, time.Second)
 			if err == nil {
 				t.Fatal("expected error got none")
 			}

--- a/pkg/collector/pod_collector.go
+++ b/pkg/collector/pod_collector.go
@@ -118,7 +118,8 @@ func (c *PodCollector) getPodMetric(pod corev1.Pod, ch chan CollectedMetric, err
 	}
 
 	ch <- CollectedMetric{
-		Type: c.metricType,
+		Namespace: c.namespace,
+		Type:      c.metricType,
 		Custom: custom_metrics.MetricValue{
 			DescribedObject: custom_metrics.ObjectReference{
 				APIVersion: "v1",

--- a/pkg/collector/prometheus_collector.go
+++ b/pkg/collector/prometheus_collector.go
@@ -174,7 +174,8 @@ func (c *PrometheusCollector) GetMetrics() ([]CollectedMetric, error) {
 	switch c.metricType {
 	case autoscalingv2.ObjectMetricSourceType:
 		metricValue = CollectedMetric{
-			Type: c.metricType,
+			Namespace: c.hpa.Namespace,
+			Type:      c.metricType,
 			Custom: custom_metrics.MetricValue{
 				DescribedObject: c.objectReference,
 				Metric:          custom_metrics.MetricIdentifier{Name: c.metric.Name, Selector: c.metric.Selector},
@@ -184,7 +185,8 @@ func (c *PrometheusCollector) GetMetrics() ([]CollectedMetric, error) {
 		}
 	case autoscalingv2.ExternalMetricSourceType:
 		metricValue = CollectedMetric{
-			Type: c.metricType,
+			Namespace: c.hpa.Namespace,
+			Type:      c.metricType,
 			External: external_metrics.ExternalMetricValue{
 				MetricName:   c.metric.Name,
 				MetricLabels: c.metric.Selector.MatchLabels,

--- a/pkg/collector/zmon_collector_test.go
+++ b/pkg/collector/zmon_collector_test.go
@@ -96,7 +96,8 @@ func TestZMONCollectorGetMetrics(tt *testing.T) {
 			},
 			collectedMetrics: []CollectedMetric{
 				{
-					Type: config.Type,
+					Namespace: "default",
+					Type:      config.Type,
 					External: external_metrics.ExternalMetricValue{
 						MetricName:   config.Metric.Name,
 						MetricLabels: config.Metric.Selector.MatchLabels,
@@ -115,7 +116,13 @@ func TestZMONCollectorGetMetrics(tt *testing.T) {
 				dataPoints: ti.dataPoints,
 			}
 
-			zmonCollector, err := NewZMONCollector(z, config, 1*time.Second)
+			hpa := &autoscalingv2.HorizontalPodAutoscaler{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+				},
+			}
+
+			zmonCollector, err := NewZMONCollector(z, hpa, config, 1*time.Second)
 			require.NoError(t, err)
 
 			metrics, _ := zmonCollector.GetMetrics()

--- a/pkg/provider/hpa.go
+++ b/pkg/provider/hpa.go
@@ -129,6 +129,7 @@ func (p *HPAProvider) updateHPAs() error {
 	newHPAs := 0
 
 	for _, hpa := range hpas.Items {
+		hpa := *hpa.DeepCopy()
 		resourceRef := resourceReference{
 			Name:      hpa.Name,
 			Namespace: hpa.Namespace,
@@ -246,7 +247,8 @@ func (p *HPAProvider) collectMetrics(ctx context.Context) {
 						value.Custom.DescribedObject.Name,
 					)
 				case autoscalingv2.ExternalMetricSourceType:
-					p.logger.Infof("Collected new external metric '%s' (%s) [%s]",
+					p.logger.Infof("Collected new external metric '%s/%s' (%s) [%s]",
+						value.Namespace,
 						value.External.MetricName,
 						value.External.Value.String(),
 						labels.Set(value.External.MetricLabels).String(),


### PR DESCRIPTION
This introduces namespacing of external metrics such that metrics from two different namespaces with the same configuration (name/labels) don't overlap.

This is done by:
1. Changing the metric store to index by namespace
2. Adding namespace when setting up a collector and pass namespace via the CollectedMetric.

Fix #255 