### PR TITLE
Feature/improve pod collector

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ metadata:
     metric-config.pods.requests-per-second.json-path/scheme: "https"
     metric-config.pods.requests-per-second.json-path/aggregator: "max"
     metric-config.pods.requests-per-second.json-path/interval: "60s" # optional
+    metric-config.pods.requests-per-second.json-path/min-pod-age: "30s" # optional
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
@@ -174,6 +175,11 @@ metric-config.pods.requests-per-second.json-path/connect-timeout: 500ms
 ```
 
 The default for both of the above values is 15 seconds.
+
+The `min-pod-age` configuration option instructs the service to start collecting metrics from the pods only if they are "older" than the specified amount of time.
+This is handy when pods need to warm up before HPAs will start tracking their metrics.
+
+The default value is 0 seconds.
 
 ## Prometheus collector
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ metadata:
     metric-config.pods.requests-per-second.json-path/scheme: "https"
     metric-config.pods.requests-per-second.json-path/aggregator: "max"
     metric-config.pods.requests-per-second.json-path/interval: "60s" # optional
-    metric-config.pods.requests-per-second.json-path/min-pod-age: "30s" # optional
+    metric-config.pods.requests-per-second.json-path/min-pod-ready-age: "30s" # optional
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
@@ -176,7 +176,7 @@ metric-config.pods.requests-per-second.json-path/connect-timeout: 500ms
 
 The default for both of the above values is 15 seconds.
 
-The `min-pod-age` configuration option instructs the service to start collecting metrics from the pods only if they are "older" than the specified amount of time.
+The `min-pod-ready-age` configuration option instructs the service to start collecting metrics from the pods only if they are "older" (time elapsed after pod reached "Ready" state) than the specified amount of time.
 This is handy when pods need to warm up before HPAs will start tracking their metrics.
 
 The default value is 0 seconds.

--- a/pkg/annotations/parser.go
+++ b/pkg/annotations/parser.go
@@ -12,6 +12,7 @@ const (
 	customMetricsPrefix      = "metric-config."
 	perReplicaMetricsConfKey = "per-replica"
 	intervalMetricsConfKey   = "interval"
+	minPodAgeConfKey         = "min-pod-age"
 )
 
 type AnnotationConfigs struct {
@@ -19,6 +20,7 @@ type AnnotationConfigs struct {
 	Configs       map[string]string
 	PerReplica    bool
 	Interval      time.Duration
+	MinPodAge     time.Duration
 }
 
 type MetricConfigKey struct {
@@ -86,6 +88,15 @@ func (m AnnotationConfigMap) Parse(annotations map[string]string) error {
 				return fmt.Errorf("failed to parse interval value %s for %s: %v", val, key, err)
 			}
 			config.Interval = interval
+			continue
+		}
+
+		if parts[1] == minPodAgeConfKey {
+			minPodAge, err := time.ParseDuration(val)
+			if err != nil {
+				return fmt.Errorf("failed to parse min-pod-age value %s for %s: %v", val, key, err)
+			}
+			config.MinPodAge = minPodAge
 			continue
 		}
 

--- a/pkg/annotations/parser.go
+++ b/pkg/annotations/parser.go
@@ -12,15 +12,15 @@ const (
 	customMetricsPrefix      = "metric-config."
 	perReplicaMetricsConfKey = "per-replica"
 	intervalMetricsConfKey   = "interval"
-	minPodAgeConfKey         = "min-pod-age"
+	minPodReadyAgeConfKey    = "min-pod-ready-age"
 )
 
 type AnnotationConfigs struct {
-	CollectorType string
-	Configs       map[string]string
-	PerReplica    bool
-	Interval      time.Duration
-	MinPodAge     time.Duration
+	CollectorType  string
+	Configs        map[string]string
+	PerReplica     bool
+	Interval       time.Duration
+	MinPodReadyAge time.Duration
 }
 
 type MetricConfigKey struct {
@@ -91,12 +91,12 @@ func (m AnnotationConfigMap) Parse(annotations map[string]string) error {
 			continue
 		}
 
-		if parts[1] == minPodAgeConfKey {
-			minPodAge, err := time.ParseDuration(val)
+		if parts[1] == minPodReadyAgeConfKey {
+			minPodReadyAge, err := time.ParseDuration(val)
 			if err != nil {
-				return fmt.Errorf("failed to parse min-pod-age value %s for %s: %v", val, key, err)
+				return fmt.Errorf("failed to parse min-pod-ready-age value %s for %s: %v", val, key, err)
 			}
-			config.MinPodAge = minPodAge
+			config.MinPodReadyAge = minPodReadyAge
 			continue
 		}
 

--- a/pkg/annotations/parser_test.go
+++ b/pkg/annotations/parser_test.go
@@ -24,10 +24,11 @@ func TestParser(t *testing.T) {
 		{
 			Name: "pod metrics",
 			Annotations: map[string]string{
-				"metric-config.pods.requests-per-second.json-path/json-key": "$.http_server.rps",
-				"metric-config.pods.requests-per-second.json-path/path":     "/metrics",
-				"metric-config.pods.requests-per-second.json-path/port":     "9090",
-				"metric-config.pods.requests-per-second.json-path/scheme":   "https",
+				"metric-config.pods.requests-per-second.json-path/json-key":      "$.http_server.rps",
+				"metric-config.pods.requests-per-second.json-path/path":          "/metrics",
+				"metric-config.pods.requests-per-second.json-path/port":          "9090",
+				"metric-config.pods.requests-per-second.json-path/scheme":        "https",
+				"metric-config.pods.requests-per-second.json-path/min-pod-age":   "30s",
 			},
 			MetricName: "requests-per-second",
 			MetricType: autoscalingv2.PodsMetricSourceType,

--- a/pkg/annotations/parser_test.go
+++ b/pkg/annotations/parser_test.go
@@ -24,11 +24,11 @@ func TestParser(t *testing.T) {
 		{
 			Name: "pod metrics",
 			Annotations: map[string]string{
-				"metric-config.pods.requests-per-second.json-path/json-key":      "$.http_server.rps",
-				"metric-config.pods.requests-per-second.json-path/path":          "/metrics",
-				"metric-config.pods.requests-per-second.json-path/port":          "9090",
-				"metric-config.pods.requests-per-second.json-path/scheme":        "https",
-				"metric-config.pods.requests-per-second.json-path/min-pod-age":   "30s",
+				"metric-config.pods.requests-per-second.json-path/json-key":    "$.http_server.rps",
+				"metric-config.pods.requests-per-second.json-path/path":        "/metrics",
+				"metric-config.pods.requests-per-second.json-path/port":        "9090",
+				"metric-config.pods.requests-per-second.json-path/scheme":      "https",
+				"metric-config.pods.requests-per-second.json-path/min-pod-age": "30s",
 			},
 			MetricName: "requests-per-second",
 			MetricType: autoscalingv2.PodsMetricSourceType,

--- a/pkg/annotations/parser_test.go
+++ b/pkg/annotations/parser_test.go
@@ -24,11 +24,11 @@ func TestParser(t *testing.T) {
 		{
 			Name: "pod metrics",
 			Annotations: map[string]string{
-				"metric-config.pods.requests-per-second.json-path/json-key":    "$.http_server.rps",
-				"metric-config.pods.requests-per-second.json-path/path":        "/metrics",
-				"metric-config.pods.requests-per-second.json-path/port":        "9090",
-				"metric-config.pods.requests-per-second.json-path/scheme":      "https",
-				"metric-config.pods.requests-per-second.json-path/min-pod-age": "30s",
+				"metric-config.pods.requests-per-second.json-path/json-key":          "$.http_server.rps",
+				"metric-config.pods.requests-per-second.json-path/path":              "/metrics",
+				"metric-config.pods.requests-per-second.json-path/port":              "9090",
+				"metric-config.pods.requests-per-second.json-path/scheme":            "https",
+				"metric-config.pods.requests-per-second.json-path/min-pod-ready-age": "30s",
 			},
 			MetricName: "requests-per-second",
 			MetricType: autoscalingv2.PodsMetricSourceType,

--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -200,7 +200,7 @@ type MetricConfig struct {
 	ObjectReference custom_metrics.ObjectReference
 	PerReplica      bool
 	Interval        time.Duration
-	MinPodAge       time.Duration
+	MinPodReadyAge  time.Duration
 	MetricSpec      autoscalingv2.MetricSpec
 }
 
@@ -259,7 +259,7 @@ func ParseHPAMetrics(hpa *autoscalingv2.HorizontalPodAutoscaler) ([]*MetricConfi
 			config.CollectorType = annotationConfigs.CollectorType
 			config.Interval = annotationConfigs.Interval
 			config.PerReplica = annotationConfigs.PerReplica
-			config.MinPodAge = annotationConfigs.MinPodAge
+			config.MinPodReadyAge = annotationConfigs.MinPodReadyAge
 			// configs specified in annotations takes precedence
 			// over labels
 			for k, v := range annotationConfigs.Configs {

--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -200,6 +200,7 @@ type MetricConfig struct {
 	ObjectReference custom_metrics.ObjectReference
 	PerReplica      bool
 	Interval        time.Duration
+	MinPodAge       time.Duration
 	MetricSpec      autoscalingv2.MetricSpec
 }
 
@@ -258,6 +259,7 @@ func ParseHPAMetrics(hpa *autoscalingv2.HorizontalPodAutoscaler) ([]*MetricConfi
 			config.CollectorType = annotationConfigs.CollectorType
 			config.Interval = annotationConfigs.Interval
 			config.PerReplica = annotationConfigs.PerReplica
+			config.MinPodAge = annotationConfigs.MinPodAge
 			// configs specified in annotations takes precedence
 			// over labels
 			for k, v := range annotationConfigs.Configs {

--- a/pkg/collector/pod_collector.go
+++ b/pkg/collector/pod_collector.go
@@ -180,7 +180,7 @@ func GetPodReadyAge(pod corev1.Pod) (bool, time.Duration) {
 		return false, podReadyAge
 	}
 	for i := range conditions {
-		if conditions[i].Type == corev1.PodReady {
+		if conditions[i].Type == corev1.PodReady && conditions[i].Status == corev1.ConditionTrue {
 			podReadyAge = time.Since(conditions[i].LastTransitionTime.Time)
 			return true, podReadyAge
 		}

--- a/pkg/collector/pod_collector.go
+++ b/pkg/collector/pod_collector.go
@@ -38,7 +38,7 @@ type PodCollector struct {
 	namespace        string
 	metric           autoscalingv2.MetricIdentifier
 	metricType       autoscalingv2.MetricSourceType
-	minPodAge				 time.Duration
+	minPodAge        time.Duration
 	interval         time.Duration
 	logger           *log.Entry
 	httpClient       *http.Client

--- a/pkg/collector/pod_collector.go
+++ b/pkg/collector/pod_collector.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	log "github.com/sirupsen/logrus"
-	"github.com/zalando-incubator/kube-metrics-adapter/pkg/collector/httpmetrics"
 	autoscalingv2 "k8s.io/api/autoscaling/v2beta2"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -15,6 +14,8 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/metrics/pkg/apis/custom_metrics"
+
+	"github.com/zalando-incubator/kube-metrics-adapter/pkg/collector/httpmetrics"
 )
 
 type PodCollectorPlugin struct {
@@ -38,7 +39,7 @@ type PodCollector struct {
 	namespace        string
 	metric           autoscalingv2.MetricIdentifier
 	metricType       autoscalingv2.MetricSourceType
-	minPodAge        time.Duration
+	minPodReadyAge   time.Duration
 	interval         time.Duration
 	logger           *log.Entry
 	httpClient       *http.Client
@@ -56,7 +57,7 @@ func NewPodCollector(client kubernetes.Interface, hpa *autoscalingv2.HorizontalP
 		namespace:        hpa.Namespace,
 		metric:           config.Metric,
 		metricType:       config.Type,
-		minPodAge:        config.MinPodAge,
+		minPodReadyAge:   config.MinPodReadyAge,
 		interval:         interval,
 		podLabelSelector: selector,
 		logger:           log.WithFields(log.Fields{"Collector": "Pod"}),
@@ -94,19 +95,19 @@ func (c *PodCollector) GetMetrics() ([]CollectedMetric, error) {
 	skippedPodsCount := 0
 
 	for _, pod := range pods.Items {
-		t := time.Now()
-		podAge := time.Duration(t.Sub(pod.ObjectMeta.CreationTimestamp.Time).Nanoseconds())
 
-		if podAge > c.minPodAge {
-			if IsPodReady(pod) {
+		isPodReady, podReadyAge := GetPodReadyAge(pod)
+
+		if isPodReady {
+			if podReadyAge > c.minPodReadyAge {
 				go c.getPodMetric(pod, ch, errCh)
 			} else {
 				skippedPodsCount++
-				c.logger.Warnf("Skipping metrics collection for pod %s because it's status is not Ready.", pod.Name)
+				c.logger.Warnf("Skipping metrics collection for pod %s because it's ready age is %s and min-pod-ready-age is set to %s", pod.Name, podReadyAge, c.minPodReadyAge)
 			}
 		} else {
 			skippedPodsCount++
-			c.logger.Warnf("Skipping metrics collection for pod %s because it's age is %s and min-pod-age is set to %s", pod.Name, podAge, c.minPodAge)
+			c.logger.Warnf("Skipping metrics collection for pod %s because it's status is not Ready.", pod.Name)
 		}
 	}
 
@@ -170,17 +171,21 @@ func getPodLabelSelector(client kubernetes.Interface, hpa *autoscalingv2.Horizon
 	return nil, fmt.Errorf("unable to get pod label selector for scale target ref '%s'", hpa.Spec.ScaleTargetRef.Kind)
 }
 
-// IsPodReady extracts corev1.PodReady condition from the given pod object and
-// returns the true if the condition corev1.PodReady is found. Returns -1 and false if the condition is not present.
-func IsPodReady(pod corev1.Pod) bool {
+// GetPodReadyAge extracts corev1.PodReady condition from the given pod object and
+// returns true, time.Duration() for pod.LastTransitionTime if the condition corev1.PodReady is found. Returns time.Duration(0s), false if the condition is not present.
+func GetPodReadyAge(pod corev1.Pod) (bool, time.Duration) {
+	t := time.Now()
+	podReadyAge := time.Duration(0 * time.Second)
 	conditions := pod.Status.Conditions
 	if conditions == nil {
-		return false
+		return false, podReadyAge
 	}
 	for i := range conditions {
 		if conditions[i].Type == corev1.PodReady {
-			return true
+			podReadyAge = time.Duration(t.Sub(conditions[i].LastTransitionTime.Time).Nanoseconds())
+			return true, podReadyAge
 		}
 	}
-	return false
+
+	return false, podReadyAge
 }

--- a/pkg/collector/pod_collector.go
+++ b/pkg/collector/pod_collector.go
@@ -99,7 +99,7 @@ func (c *PodCollector) GetMetrics() ([]CollectedMetric, error) {
 		isPodReady, podReadyAge := GetPodReadyAge(pod)
 
 		if isPodReady {
-			if podReadyAge > c.minPodReadyAge {
+			if podReadyAge >= c.minPodReadyAge {
 				go c.getPodMetric(pod, ch, errCh)
 			} else {
 				skippedPodsCount++
@@ -182,7 +182,6 @@ func GetPodReadyAge(pod corev1.Pod) (bool, time.Duration) {
 	for i := range conditions {
 		if conditions[i].Type == corev1.PodReady {
 			podReadyAge = time.Since(conditions[i].LastTransitionTime.Time)
-			fmt.Printf("podReadyAge: %s", podReadyAge)
 			return true, podReadyAge
 		}
 	}

--- a/pkg/collector/pod_collector_test.go
+++ b/pkg/collector/pod_collector_test.go
@@ -179,7 +179,7 @@ func makeTestConfig(port string, minPodAge time.Duration) *MetricConfig {
 	return &MetricConfig{
 		CollectorType: "json-path",
 		Config:        map[string]string{"json-key": "$.values", "port": port, "path": "/metrics", "aggregator": "sum"},
-		MinPodAge: minPodAge,
+		MinPodAge:     minPodAge,
 	}
 }
 
@@ -195,7 +195,7 @@ func makeTestPods(t *testing.T, testServer string, metricName string, port strin
 				CreationTimestamp: creationTimestamp,
 			},
 			Status: corev1.PodStatus{
-				PodIP: testServer,
+				PodIP:      testServer,
 				Conditions: []corev1.PodCondition{podCondition},
 			},
 		}

--- a/pkg/collector/pod_collector_test.go
+++ b/pkg/collector/pod_collector_test.go
@@ -47,7 +47,7 @@ func TestPodCollector(t *testing.T) {
 			host, port, metricsHandler := makeTestHTTPServer(t, tc.metrics)
 			lastReadyTransitionTimeTimestamp := v1.NewTime(time.Now().Add(time.Duration(-30) * time.Second))
 			minPodReadyAge := time.Duration(0 * time.Second)
-			podCondition := corev1.PodCondition{Type: corev1.PodReady, Status: corev1.ConditionStatus(corev1.PodRunning), LastTransitionTime: lastReadyTransitionTimeTimestamp}
+			podCondition := corev1.PodCondition{Type: corev1.PodReady, Status: corev1.ConditionTrue, LastTransitionTime: lastReadyTransitionTimeTimestamp}
 			makeTestPods(t, host, port, "test-metric", client, 5, podCondition)
 			testHPA := makeTestHPA(t, client)
 			testConfig := makeTestConfig(port, minPodReadyAge)
@@ -86,7 +86,7 @@ func TestPodCollectorWithMinPodReadyAge(t *testing.T) {
 			lastReadyTransitionTimeTimestamp := v1.NewTime(time.Now().Add(time.Duration(-30) * time.Second))
 			// Pods that are not older that 60 seconds (all in this case) should not be processed
 			minPodReadyAge := time.Duration(60 * time.Second)
-			podCondition := corev1.PodCondition{Type: corev1.PodReady, Status: corev1.ConditionStatus(corev1.PodRunning), LastTransitionTime: lastReadyTransitionTimeTimestamp}
+			podCondition := corev1.PodCondition{Type: corev1.PodReady, Status: corev1.ConditionTrue, LastTransitionTime: lastReadyTransitionTimeTimestamp}
 			makeTestPods(t, host, port, "test-metric", client, 5, podCondition)
 			testHPA := makeTestHPA(t, client)
 			testConfig := makeTestConfig(port, minPodReadyAge)
@@ -123,8 +123,8 @@ func TestPodCollectorWithPodCondition(t *testing.T) {
 			host, port, metricsHandler := makeTestHTTPServer(t, tc.metrics)
 			lastScheduledTransitionTimeTimestamp := v1.NewTime(time.Now().Add(time.Duration(-30) * time.Second))
 			minPodReadyAge := time.Duration(0 * time.Second)
-			//Pods in state corev1.PodScheduled should not be processed
-			podCondition := corev1.PodCondition{Type: corev1.PodScheduled, Status: corev1.ConditionStatus(corev1.PodRunning), LastTransitionTime: lastScheduledTransitionTimeTimestamp}
+			//Pods in state corev1.PodReady == corev1.ConditionFalse should not be processed
+			podCondition := corev1.PodCondition{Type: corev1.PodReady, Status: corev1.ConditionFalse, LastTransitionTime: lastScheduledTransitionTimeTimestamp}
 			makeTestPods(t, host, port, "test-metric", client, 5, podCondition)
 			testHPA := makeTestHPA(t, client)
 			testConfig := makeTestConfig(port, minPodReadyAge)


### PR DESCRIPTION
# Improved pod collector, introduced **pod-min-age** configuration option

## Description
In order to prevent the situations when fresh pods can return unstable metrics while they're warming up - introducing `min-pod-age` configuration option. This option allows us to add a delay before collector starts gathering metrics from the pods.

Also, I've noticed that pod collector starts querying pods without consideration of their status. I've added IsPodReady conditional check before attempting querying the metrics.

For example, In our case we're using an upstream response times as an additional scaling metric.
However, when we're performing the deployments, the values for response times are very high for the first couple of seconds after new pods have been started. This leads to the situation when kube-metrics-adapter triggers a scale up of our HPAs.

## Types of Changes

- New feature (non-breaking change which adds functionality)
- Configuration change
- Documentation / non-code

## Review
- [ X] Tests
- [ X] Documentation
- [ X] CHANGELOG
