### PR TITLE
add commandline flags to set GC interval and metrics TTL

### DIFF
--- a/pkg/provider/hpa_test.go
+++ b/pkg/provider/hpa_test.go
@@ -106,7 +106,7 @@ func TestUpdateHPAs(t *testing.T) {
 	err = collectorFactory.RegisterPodsCollector("", mockCollectorPlugin{})
 	require.NoError(t, err)
 
-	provider := NewHPAProvider(fakeClient, 1*time.Second, 1*time.Second, collectorFactory, false)
+	provider := NewHPAProvider(fakeClient, 1*time.Second, 1*time.Second, collectorFactory, false, 1*time.Second, 1*time.Second)
 	provider.collectorScheduler = NewCollectorScheduler(context.Background(), provider.metricSink)
 
 	err = provider.updateHPAs()
@@ -171,7 +171,7 @@ func TestUpdateHPAsDisregardingIncompatibleHPA(t *testing.T) {
 	require.NoError(t, err)
 
 	eventRecorder := &mockEventRecorder{}
-	provider := NewHPAProvider(fakeClient, 1*time.Second, 1*time.Second, collectorFactory, true)
+	provider := NewHPAProvider(fakeClient, 1*time.Second, 1*time.Second, collectorFactory, true, 1*time.Second, 1*time.Second)
 	provider.recorder = eventRecorder
 	provider.collectorScheduler = NewCollectorScheduler(context.Background(), provider.metricSink)
 
@@ -183,7 +183,7 @@ func TestUpdateHPAsDisregardingIncompatibleHPA(t *testing.T) {
 
 	// check for events when disregardIncompatibleHPAs=false
 	eventRecorder = &mockEventRecorder{}
-	provider = NewHPAProvider(fakeClient, 1*time.Second, 1*time.Second, collectorFactory, false)
+	provider = NewHPAProvider(fakeClient, 1*time.Second, 1*time.Second, collectorFactory, false, 1*time.Second, 1*time.Second)
 	provider.recorder = eventRecorder
 	provider.collectorScheduler = NewCollectorScheduler(context.Background(), provider.metricSink)
 


### PR DESCRIPTION
Signed-off-by: Harman Singh <iamgrewal7@gmail.com>

# One-line summary
add commandline flags to set GC interval and metrics TTL
> Issue : #97  (only if appropriate)

## Types of Changes
_What types of changes does your code introduce? Keep the ones that apply:_

- New feature (non-breaking change which adds functionality)
- Bug fix (non-breaking change which fixes an issue)

## Tasks
_List of tasks you will do to complete the PR_
  - [x] Get all automated checks green
  - [x] Get PR reviewed

## Review
_List of tasks the reviewer must do to review the PR_
- [ ] Tests
- [ ] Documentation
- [ ] CHANGELOG

## Deployment Notes
These should highlight any db migrations, feature toggles, etc.
