### PR TITLE
Updated apiservice to v1

### DIFF
--- a/docs/custom-metrics-apiservice.yaml
+++ b/docs/custom-metrics-apiservice.yaml
@@ -1,13 +1,13 @@
 apiVersion: apiregistration.k8s.io/v1
 kind: APIService
 metadata:
-  name: v1.custom.metrics.k8s.io
+  name: v1beta1.custom.metrics.k8s.io
 spec:
   service:
     name: kube-metrics-adapter
     namespace: kube-system
   group: custom.metrics.k8s.io
-  version: v1
+  version: v1beta1
   insecureSkipTLSVerify: true
   groupPriorityMinimum: 100
   versionPriority: 100

--- a/docs/custom-metrics-apiservice.yaml
+++ b/docs/custom-metrics-apiservice.yaml
@@ -1,13 +1,13 @@
-apiVersion: apiregistration.k8s.io/v1beta1
+apiVersion: apiregistration.k8s.io/v1
 kind: APIService
 metadata:
-  name: v1beta1.custom.metrics.k8s.io
+  name: v1.custom.metrics.k8s.io
 spec:
   service:
     name: kube-metrics-adapter
     namespace: kube-system
   group: custom.metrics.k8s.io
-  version: v1beta1
+  version: v1
   insecureSkipTLSVerify: true
   groupPriorityMinimum: 100
   versionPriority: 100

--- a/docs/external-metrics-apiservice.yaml
+++ b/docs/external-metrics-apiservice.yaml
@@ -1,13 +1,13 @@
-apiVersion: apiregistration.k8s.io/v1beta1
+apiVersion: apiregistration.k8s.io/v1
 kind: APIService
 metadata:
-  name: v1beta1.external.metrics.k8s.io
+  name: v1.external.metrics.k8s.io
 spec:
   service:
     name: kube-metrics-adapter
     namespace: kube-system
   group: external.metrics.k8s.io
-  version: v1beta1
+  version: v1
   insecureSkipTLSVerify: true
   groupPriorityMinimum: 100
   versionPriority: 100

--- a/docs/external-metrics-apiservice.yaml
+++ b/docs/external-metrics-apiservice.yaml
@@ -1,13 +1,13 @@
 apiVersion: apiregistration.k8s.io/v1
 kind: APIService
 metadata:
-  name: v1.external.metrics.k8s.io
+  name: v1beta1.external.metrics.k8s.io
 spec:
   service:
     name: kube-metrics-adapter
     namespace: kube-system
   group: external.metrics.k8s.io
-  version: v1
+  version: v1beta1
   insecureSkipTLSVerify: true
   groupPriorityMinimum: 100
   versionPriority: 100

--- a/docs/helm/templates/custom-metrics-apiservice.yaml
+++ b/docs/helm/templates/custom-metrics-apiservice.yaml
@@ -1,14 +1,14 @@
 {{- if .Values.enableCustomMetricsApi }}
-apiVersion: apiregistration.k8s.io/v1beta1
+apiVersion: apiregistration.k8s.io/v1
 kind: APIService
 metadata:
-  name: v1beta1.custom.metrics.k8s.io
+  name: v1.custom.metrics.k8s.io
 spec:
   service:
     name: kube-metrics-adapter
     namespace: {{ .Values.namespace }}
   group: custom.metrics.k8s.io
-  version: v1beta1
+  version: v1
   insecureSkipTLSVerify: {{ .Values.tls.skipTLSVerify }}
   groupPriorityMinimum: 100
   versionPriority: 100

--- a/docs/helm/templates/custom-metrics-apiservice.yaml
+++ b/docs/helm/templates/custom-metrics-apiservice.yaml
@@ -2,13 +2,13 @@
 apiVersion: apiregistration.k8s.io/v1
 kind: APIService
 metadata:
-  name: v1.custom.metrics.k8s.io
+  name: v1beta1.custom.metrics.k8s.io
 spec:
   service:
     name: kube-metrics-adapter
     namespace: {{ .Values.namespace }}
   group: custom.metrics.k8s.io
-  version: v1
+  version: v1beta1
   insecureSkipTLSVerify: {{ .Values.tls.skipTLSVerify }}
   groupPriorityMinimum: 100
   versionPriority: 100

--- a/docs/helm/templates/external-metrics-apiservice.yaml
+++ b/docs/helm/templates/external-metrics-apiservice.yaml
@@ -1,14 +1,14 @@
 {{- if .Values.enableExternalMetricsApi }}
-apiVersion: apiregistration.k8s.io/v1beta1
+apiVersion: apiregistration.k8s.io/v1
 kind: APIService
 metadata:
-  name: v1beta1.external.metrics.k8s.io
+  name: v1.external.metrics.k8s.io
 spec:
   service:
     name: kube-metrics-adapter
     namespace: {{ .Values.namespace }}
   group: external.metrics.k8s.io
-  version: v1beta1
+  version: v1
   insecureSkipTLSVerify: {{ .Values.tls.skipTLSVerify }}
   groupPriorityMinimum: 100
   versionPriority: 100

--- a/docs/helm/templates/external-metrics-apiservice.yaml
+++ b/docs/helm/templates/external-metrics-apiservice.yaml
@@ -2,13 +2,13 @@
 apiVersion: apiregistration.k8s.io/v1
 kind: APIService
 metadata:
-  name: v1.external.metrics.k8s.io
+  name: v1beta1.external.metrics.k8s.io
 spec:
   service:
     name: kube-metrics-adapter
     namespace: {{ .Values.namespace }}
   group: external.metrics.k8s.io
-  version: v1
+  version: v1beta1
   insecureSkipTLSVerify: {{ .Values.tls.skipTLSVerify }}
   groupPriorityMinimum: 100
   versionPriority: 100


### PR DESCRIPTION
# Updated APIService from v1beta1 to v1

## Description
When installing this adapter into Kubernetes v1.19+, you will receive the following deprecation notice:
```
W0426 10:49:35.932780     318 warnings.go:70] apiregistration.k8s.io/v1beta1 APIService is deprecated in v1.19+, unavailable in v1.22+; use apiregistration.k8s.io/v1 APIService
```

This migration was described by the [KubernetesDeprecation Guide](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#apiservice-v122) as one with "No notable changes", so there should be no functionality change.

## Types of Changes
_What types of changes does your code introduce? Keep the ones that apply:_

- Bug fix (non-breaking change which fixes an issue)

## Tasks
_List of tasks you will do to complete the PR_
  - [x] Replaced all instances of `apiregistration.k8s.io/v1beta1` with `apiregistration.k8s.io/v1`

## Review
_List of tasks the reviewer must do to review the PR_
- [ ] Verify that `apiregistration.k8s.io/v1` substitutions are correct and not misspelled.

## Deployment Notes
Should be deployed before Kubernetes v1.22.
