### PR TITLE
Bump to v0.1.10 for helm

### DIFF
--- a/docs/helm/Chart.yaml
+++ b/docs/helm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: kube-metrics-adapter
-version: 0.1.9
+version: 0.1.10
 description: kube-metrics-adapter helm chart
 home: https://github.com/zalando-incubator/kube-metrics-adapter
 maintainers:

--- a/docs/helm/values.yaml
+++ b/docs/helm/values.yaml
@@ -4,7 +4,7 @@ replicas: 1
 
 registry:
   image: registry.opensource.zalan.do/teapot/kube-metrics-adapter
-  imageTag: v0.1.9
+  imageTag: v0.1.10
   imagePullPolicy: IfNotPresent
 
 service:


### PR DESCRIPTION
# Version bump for included helm charts


> Issue : #257

## Description
Partially addresses #257 where prometheus external was not functioning. Unlike 0.1.9, this version does have working external Prometheus metrics and my local testing indicates that using 0.1.10 works normally!

## Types of Changes
_What types of changes does your code introduce? Keep the ones that apply:_

- Bug fix through version bump

## Tasks
_List of tasks you will do to complete the PR_
  - [x] Updated image in helm chart with newest version

## Review
_List of tasks the reviewer must do to review the PR_
- [ ] Double check that older version 0.1.9 does not exist anywhere else in case I missed a place.

