### PR TITLE
Feature/stop processing non runing pods

### DIFF
--- a/pkg/collector/pod_collector.go
+++ b/pkg/collector/pod_collector.go
@@ -101,7 +101,7 @@ func (c *PodCollector) GetMetrics() ([]CollectedMetric, error) {
 		if isPodReady {
 			if pod.DeletionTimestamp != nil {
 				skippedPodsCount++
-				c.logger.Warnf("Skipping metrics collection for pod %s/%s because it is seems to be scheduled for termination (DeletionTimestamp: %s)", pod.Namespace, pod.Name, pod.DeletionTimestamp)
+				c.logger.Debugf("Skipping metrics collection for pod %s/%s because it is being terminated (DeletionTimestamp: %s)", pod.Namespace, pod.Name, pod.DeletionTimestamp)
 			} else if podReadyAge < c.minPodReadyAge {
 				skippedPodsCount++
 				c.logger.Warnf("Skipping metrics collection for pod %s/%s because it's ready age is %s and min-pod-ready-age is set to %s", pod.Namespace, pod.Name, podReadyAge, c.minPodReadyAge)
@@ -110,7 +110,7 @@ func (c *PodCollector) GetMetrics() ([]CollectedMetric, error) {
 			}
 		} else {
 			skippedPodsCount++
-			c.logger.Warnf("Skipping metrics collection for pod %s/%s because it's status is not Ready.", pod.Namespace, pod.Name)
+			c.logger.Debugf("Skipping metrics collection for pod %s/%s because it's status is not Ready.", pod.Namespace, pod.Name)
 		}
 	}
 

--- a/pkg/collector/pod_collector.go
+++ b/pkg/collector/pod_collector.go
@@ -106,7 +106,7 @@ func (c *PodCollector) GetMetrics() ([]CollectedMetric, error) {
 				skippedPodsCount++
 				c.logger.Warnf("Skipping metrics collection for pod %s/%s because it's ready age is %s and min-pod-ready-age is set to %s", pod.Namespace, pod.Name, podReadyAge, c.minPodReadyAge)
 			} else {
-        go c.getPodMetric(pod, ch, errCh)
+				go c.getPodMetric(pod, ch, errCh)
 			}
 		} else {
 			skippedPodsCount++

--- a/pkg/collector/pod_collector_test.go
+++ b/pkg/collector/pod_collector_test.go
@@ -227,8 +227,6 @@ func makeTestConfig(port string, minPodReadyAge time.Duration) *MetricConfig {
 }
 
 func makeTestPods(t *testing.T, testServer string, metricName string, port string, client kubernetes.Interface, replicas int, podCondition corev1.PodCondition, podDeletionTimestamp time.Time) {
-
-
 	for i := 0; i < replicas; i++ {
 		testPod := &corev1.Pod{
 			ObjectMeta: v1.ObjectMeta{

--- a/pkg/collector/pod_collector_test.go
+++ b/pkg/collector/pod_collector_test.go
@@ -49,7 +49,7 @@ func TestPodCollector(t *testing.T) {
 			minPodReadyAge := time.Duration(0 * time.Second)
 			podCondition := corev1.PodCondition{Type: corev1.PodReady, Status: corev1.ConditionTrue, LastTransitionTime: lastReadyTransitionTimeTimestamp}
 			podDeletionTimestamp := time.Time{}
-			makeTestPods(t, host, port, "test-metric", client, 5, podCondition,podDeletionTimestamp)
+			makeTestPods(t, host, port, "test-metric", client, 5, podCondition, podDeletionTimestamp)
 			testHPA := makeTestHPA(t, client)
 			testConfig := makeTestConfig(port, minPodReadyAge)
 			collector, err := plugin.NewCollector(testHPA, testConfig, testInterval)
@@ -144,7 +144,6 @@ func TestPodCollectorWithPodCondition(t *testing.T) {
 		})
 	}
 }
-
 
 func TestPodCollectorWithPodTerminatingCondition(t *testing.T) {
 	for _, tc := range []struct {
@@ -241,8 +240,8 @@ func makeTestPods(t *testing.T, testServer string, metricName string, port strin
 				Conditions: []corev1.PodCondition{podCondition},
 			},
 		}
-    
-		if podDeletionTimestamp.IsZero(){
+
+		if podDeletionTimestamp.IsZero() {
 			testPod.ObjectMeta.DeletionTimestamp = nil
 		} else {
 			testPod.ObjectMeta.DeletionTimestamp = &v1.Time{Time: podDeletionTimestamp}


### PR DESCRIPTION
Signed-off-by: Anatolii Dutchak <adutchak-x@tunein.com>

# One-line summary

Skipping pods which might be in "Termination" state

## Description
It seems to be that we did not consider the situation where some of the pods can be in "Terminating" state. We actually don't want to collect the metrics from pods scheduled for deletion.

## Types of Changes

- New feature (non-breaking change which adds functionality)
- Bug fix (non-breaking change which fixes an issue)
- Refactor/improvements

## Review
_List of tasks the reviewer must do to review the PR_
- [X ] Tests
