### PR TITLE
Remove ClusterScalingSchedule clients namespace

### DIFF
--- a/pkg/apis/zalando.org/v1/types.go
+++ b/pkg/apis/zalando.org/v1/types.go
@@ -19,6 +19,7 @@ type ScalingSchedule struct {
 }
 
 // +genclient
+// +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:object:root=true
 

--- a/pkg/client/clientset/versioned/typed/zalando.org/v1/clusterscalingschedule.go
+++ b/pkg/client/clientset/versioned/typed/zalando.org/v1/clusterscalingschedule.go
@@ -33,7 +33,7 @@ import (
 // ClusterScalingSchedulesGetter has a method to return a ClusterScalingScheduleInterface.
 // A group's client should implement this interface.
 type ClusterScalingSchedulesGetter interface {
-	ClusterScalingSchedules(namespace string) ClusterScalingScheduleInterface
+	ClusterScalingSchedules() ClusterScalingScheduleInterface
 }
 
 // ClusterScalingScheduleInterface has methods to work with ClusterScalingSchedule resources.
@@ -52,14 +52,12 @@ type ClusterScalingScheduleInterface interface {
 // clusterScalingSchedules implements ClusterScalingScheduleInterface
 type clusterScalingSchedules struct {
 	client rest.Interface
-	ns     string
 }
 
 // newClusterScalingSchedules returns a ClusterScalingSchedules
-func newClusterScalingSchedules(c *ZalandoV1Client, namespace string) *clusterScalingSchedules {
+func newClusterScalingSchedules(c *ZalandoV1Client) *clusterScalingSchedules {
 	return &clusterScalingSchedules{
 		client: c.RESTClient(),
-		ns:     namespace,
 	}
 }
 
@@ -67,7 +65,6 @@ func newClusterScalingSchedules(c *ZalandoV1Client, namespace string) *clusterSc
 func (c *clusterScalingSchedules) Get(ctx context.Context, name string, options metav1.GetOptions) (result *v1.ClusterScalingSchedule, err error) {
 	result = &v1.ClusterScalingSchedule{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("clusterscalingschedules").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -84,7 +81,6 @@ func (c *clusterScalingSchedules) List(ctx context.Context, opts metav1.ListOpti
 	}
 	result = &v1.ClusterScalingScheduleList{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("clusterscalingschedules").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -101,7 +97,6 @@ func (c *clusterScalingSchedules) Watch(ctx context.Context, opts metav1.ListOpt
 	}
 	opts.Watch = true
 	return c.client.Get().
-		Namespace(c.ns).
 		Resource("clusterscalingschedules").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -112,7 +107,6 @@ func (c *clusterScalingSchedules) Watch(ctx context.Context, opts metav1.ListOpt
 func (c *clusterScalingSchedules) Create(ctx context.Context, clusterScalingSchedule *v1.ClusterScalingSchedule, opts metav1.CreateOptions) (result *v1.ClusterScalingSchedule, err error) {
 	result = &v1.ClusterScalingSchedule{}
 	err = c.client.Post().
-		Namespace(c.ns).
 		Resource("clusterscalingschedules").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(clusterScalingSchedule).
@@ -125,7 +119,6 @@ func (c *clusterScalingSchedules) Create(ctx context.Context, clusterScalingSche
 func (c *clusterScalingSchedules) Update(ctx context.Context, clusterScalingSchedule *v1.ClusterScalingSchedule, opts metav1.UpdateOptions) (result *v1.ClusterScalingSchedule, err error) {
 	result = &v1.ClusterScalingSchedule{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("clusterscalingschedules").
 		Name(clusterScalingSchedule.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -138,7 +131,6 @@ func (c *clusterScalingSchedules) Update(ctx context.Context, clusterScalingSche
 // Delete takes name of the clusterScalingSchedule and deletes it. Returns an error if one occurs.
 func (c *clusterScalingSchedules) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("clusterscalingschedules").
 		Name(name).
 		Body(&opts).
@@ -153,7 +145,6 @@ func (c *clusterScalingSchedules) DeleteCollection(ctx context.Context, opts met
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("clusterscalingschedules").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -166,7 +157,6 @@ func (c *clusterScalingSchedules) DeleteCollection(ctx context.Context, opts met
 func (c *clusterScalingSchedules) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *v1.ClusterScalingSchedule, err error) {
 	result = &v1.ClusterScalingSchedule{}
 	err = c.client.Patch(pt).
-		Namespace(c.ns).
 		Resource("clusterscalingschedules").
 		Name(name).
 		SubResource(subresources...).

--- a/pkg/client/clientset/versioned/typed/zalando.org/v1/fake/fake_clusterscalingschedule.go
+++ b/pkg/client/clientset/versioned/typed/zalando.org/v1/fake/fake_clusterscalingschedule.go
@@ -33,7 +33,6 @@ import (
 // FakeClusterScalingSchedules implements ClusterScalingScheduleInterface
 type FakeClusterScalingSchedules struct {
 	Fake *FakeZalandoV1
-	ns   string
 }
 
 var clusterscalingschedulesResource = schema.GroupVersionResource{Group: "zalando.org", Version: "v1", Resource: "clusterscalingschedules"}
@@ -43,8 +42,7 @@ var clusterscalingschedulesKind = schema.GroupVersionKind{Group: "zalando.org", 
 // Get takes name of the clusterScalingSchedule, and returns the corresponding clusterScalingSchedule object, and an error if there is any.
 func (c *FakeClusterScalingSchedules) Get(ctx context.Context, name string, options v1.GetOptions) (result *zalandoorgv1.ClusterScalingSchedule, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(clusterscalingschedulesResource, c.ns, name), &zalandoorgv1.ClusterScalingSchedule{})
-
+		Invokes(testing.NewRootGetAction(clusterscalingschedulesResource, name), &zalandoorgv1.ClusterScalingSchedule{})
 	if obj == nil {
 		return nil, err
 	}
@@ -54,8 +52,7 @@ func (c *FakeClusterScalingSchedules) Get(ctx context.Context, name string, opti
 // List takes label and field selectors, and returns the list of ClusterScalingSchedules that match those selectors.
 func (c *FakeClusterScalingSchedules) List(ctx context.Context, opts v1.ListOptions) (result *zalandoorgv1.ClusterScalingScheduleList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewListAction(clusterscalingschedulesResource, clusterscalingschedulesKind, c.ns, opts), &zalandoorgv1.ClusterScalingScheduleList{})
-
+		Invokes(testing.NewRootListAction(clusterscalingschedulesResource, clusterscalingschedulesKind, opts), &zalandoorgv1.ClusterScalingScheduleList{})
 	if obj == nil {
 		return nil, err
 	}
@@ -76,15 +73,13 @@ func (c *FakeClusterScalingSchedules) List(ctx context.Context, opts v1.ListOpti
 // Watch returns a watch.Interface that watches the requested clusterScalingSchedules.
 func (c *FakeClusterScalingSchedules) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
-		InvokesWatch(testing.NewWatchAction(clusterscalingschedulesResource, c.ns, opts))
-
+		InvokesWatch(testing.NewRootWatchAction(clusterscalingschedulesResource, opts))
 }
 
 // Create takes the representation of a clusterScalingSchedule and creates it.  Returns the server's representation of the clusterScalingSchedule, and an error, if there is any.
 func (c *FakeClusterScalingSchedules) Create(ctx context.Context, clusterScalingSchedule *zalandoorgv1.ClusterScalingSchedule, opts v1.CreateOptions) (result *zalandoorgv1.ClusterScalingSchedule, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(clusterscalingschedulesResource, c.ns, clusterScalingSchedule), &zalandoorgv1.ClusterScalingSchedule{})
-
+		Invokes(testing.NewRootCreateAction(clusterscalingschedulesResource, clusterScalingSchedule), &zalandoorgv1.ClusterScalingSchedule{})
 	if obj == nil {
 		return nil, err
 	}
@@ -94,8 +89,7 @@ func (c *FakeClusterScalingSchedules) Create(ctx context.Context, clusterScaling
 // Update takes the representation of a clusterScalingSchedule and updates it. Returns the server's representation of the clusterScalingSchedule, and an error, if there is any.
 func (c *FakeClusterScalingSchedules) Update(ctx context.Context, clusterScalingSchedule *zalandoorgv1.ClusterScalingSchedule, opts v1.UpdateOptions) (result *zalandoorgv1.ClusterScalingSchedule, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(clusterscalingschedulesResource, c.ns, clusterScalingSchedule), &zalandoorgv1.ClusterScalingSchedule{})
-
+		Invokes(testing.NewRootUpdateAction(clusterscalingschedulesResource, clusterScalingSchedule), &zalandoorgv1.ClusterScalingSchedule{})
 	if obj == nil {
 		return nil, err
 	}
@@ -105,14 +99,13 @@ func (c *FakeClusterScalingSchedules) Update(ctx context.Context, clusterScaling
 // Delete takes name of the clusterScalingSchedule and deletes it. Returns an error if one occurs.
 func (c *FakeClusterScalingSchedules) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(clusterscalingschedulesResource, c.ns, name), &zalandoorgv1.ClusterScalingSchedule{})
-
+		Invokes(testing.NewRootDeleteAction(clusterscalingschedulesResource, name), &zalandoorgv1.ClusterScalingSchedule{})
 	return err
 }
 
 // DeleteCollection deletes a collection of objects.
 func (c *FakeClusterScalingSchedules) DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(clusterscalingschedulesResource, c.ns, listOpts)
+	action := testing.NewRootDeleteCollectionAction(clusterscalingschedulesResource, listOpts)
 
 	_, err := c.Fake.Invokes(action, &zalandoorgv1.ClusterScalingScheduleList{})
 	return err
@@ -121,8 +114,7 @@ func (c *FakeClusterScalingSchedules) DeleteCollection(ctx context.Context, opts
 // Patch applies the patch and returns the patched clusterScalingSchedule.
 func (c *FakeClusterScalingSchedules) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *zalandoorgv1.ClusterScalingSchedule, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(clusterscalingschedulesResource, c.ns, name, pt, data, subresources...), &zalandoorgv1.ClusterScalingSchedule{})
-
+		Invokes(testing.NewRootPatchSubresourceAction(clusterscalingschedulesResource, name, pt, data, subresources...), &zalandoorgv1.ClusterScalingSchedule{})
 	if obj == nil {
 		return nil, err
 	}

--- a/pkg/client/clientset/versioned/typed/zalando.org/v1/fake/fake_zalando.org_client.go
+++ b/pkg/client/clientset/versioned/typed/zalando.org/v1/fake/fake_zalando.org_client.go
@@ -28,8 +28,8 @@ type FakeZalandoV1 struct {
 	*testing.Fake
 }
 
-func (c *FakeZalandoV1) ClusterScalingSchedules(namespace string) v1.ClusterScalingScheduleInterface {
-	return &FakeClusterScalingSchedules{c, namespace}
+func (c *FakeZalandoV1) ClusterScalingSchedules() v1.ClusterScalingScheduleInterface {
+	return &FakeClusterScalingSchedules{c}
 }
 
 func (c *FakeZalandoV1) ScalingSchedules(namespace string) v1.ScalingScheduleInterface {

--- a/pkg/client/clientset/versioned/typed/zalando.org/v1/zalando.org_client.go
+++ b/pkg/client/clientset/versioned/typed/zalando.org/v1/zalando.org_client.go
@@ -35,8 +35,8 @@ type ZalandoV1Client struct {
 	restClient rest.Interface
 }
 
-func (c *ZalandoV1Client) ClusterScalingSchedules(namespace string) ClusterScalingScheduleInterface {
-	return newClusterScalingSchedules(c, namespace)
+func (c *ZalandoV1Client) ClusterScalingSchedules() ClusterScalingScheduleInterface {
+	return newClusterScalingSchedules(c)
 }
 
 func (c *ZalandoV1Client) ScalingSchedules(namespace string) ScalingScheduleInterface {

--- a/pkg/client/informers/externalversions/zalando.org/v1/clusterscalingschedule.go
+++ b/pkg/client/informers/externalversions/zalando.org/v1/clusterscalingschedule.go
@@ -42,33 +42,32 @@ type ClusterScalingScheduleInformer interface {
 type clusterScalingScheduleInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
 	tweakListOptions internalinterfaces.TweakListOptionsFunc
-	namespace        string
 }
 
 // NewClusterScalingScheduleInformer constructs a new informer for ClusterScalingSchedule type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewClusterScalingScheduleInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
-	return NewFilteredClusterScalingScheduleInformer(client, namespace, resyncPeriod, indexers, nil)
+func NewClusterScalingScheduleInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return NewFilteredClusterScalingScheduleInformer(client, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredClusterScalingScheduleInformer constructs a new informer for ClusterScalingSchedule type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredClusterScalingScheduleInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredClusterScalingScheduleInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
 	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.ZalandoV1().ClusterScalingSchedules(namespace).List(context.TODO(), options)
+				return client.ZalandoV1().ClusterScalingSchedules().List(context.TODO(), options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.ZalandoV1().ClusterScalingSchedules(namespace).Watch(context.TODO(), options)
+				return client.ZalandoV1().ClusterScalingSchedules().Watch(context.TODO(), options)
 			},
 		},
 		&zalandoorgv1.ClusterScalingSchedule{},
@@ -78,7 +77,7 @@ func NewFilteredClusterScalingScheduleInformer(client versioned.Interface, names
 }
 
 func (f *clusterScalingScheduleInformer) defaultInformer(client versioned.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredClusterScalingScheduleInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	return NewFilteredClusterScalingScheduleInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
 }
 
 func (f *clusterScalingScheduleInformer) Informer() cache.SharedIndexInformer {

--- a/pkg/client/informers/externalversions/zalando.org/v1/interface.go
+++ b/pkg/client/informers/externalversions/zalando.org/v1/interface.go
@@ -43,7 +43,7 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 
 // ClusterScalingSchedules returns a ClusterScalingScheduleInformer.
 func (v *version) ClusterScalingSchedules() ClusterScalingScheduleInformer {
-	return &clusterScalingScheduleInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
+	return &clusterScalingScheduleInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }
 
 // ScalingSchedules returns a ScalingScheduleInformer.

--- a/pkg/client/listers/zalando.org/v1/clusterscalingschedule.go
+++ b/pkg/client/listers/zalando.org/v1/clusterscalingschedule.go
@@ -31,8 +31,9 @@ type ClusterScalingScheduleLister interface {
 	// List lists all ClusterScalingSchedules in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1.ClusterScalingSchedule, err error)
-	// ClusterScalingSchedules returns an object that can list and get ClusterScalingSchedules.
-	ClusterScalingSchedules(namespace string) ClusterScalingScheduleNamespaceLister
+	// Get retrieves the ClusterScalingSchedule from the index for a given name.
+	// Objects returned here must be treated as read-only.
+	Get(name string) (*v1.ClusterScalingSchedule, error)
 	ClusterScalingScheduleListerExpansion
 }
 
@@ -54,41 +55,9 @@ func (s *clusterScalingScheduleLister) List(selector labels.Selector) (ret []*v1
 	return ret, err
 }
 
-// ClusterScalingSchedules returns an object that can list and get ClusterScalingSchedules.
-func (s *clusterScalingScheduleLister) ClusterScalingSchedules(namespace string) ClusterScalingScheduleNamespaceLister {
-	return clusterScalingScheduleNamespaceLister{indexer: s.indexer, namespace: namespace}
-}
-
-// ClusterScalingScheduleNamespaceLister helps list and get ClusterScalingSchedules.
-// All objects returned here must be treated as read-only.
-type ClusterScalingScheduleNamespaceLister interface {
-	// List lists all ClusterScalingSchedules in the indexer for a given namespace.
-	// Objects returned here must be treated as read-only.
-	List(selector labels.Selector) (ret []*v1.ClusterScalingSchedule, err error)
-	// Get retrieves the ClusterScalingSchedule from the indexer for a given namespace and name.
-	// Objects returned here must be treated as read-only.
-	Get(name string) (*v1.ClusterScalingSchedule, error)
-	ClusterScalingScheduleNamespaceListerExpansion
-}
-
-// clusterScalingScheduleNamespaceLister implements the ClusterScalingScheduleNamespaceLister
-// interface.
-type clusterScalingScheduleNamespaceLister struct {
-	indexer   cache.Indexer
-	namespace string
-}
-
-// List lists all ClusterScalingSchedules in the indexer for a given namespace.
-func (s clusterScalingScheduleNamespaceLister) List(selector labels.Selector) (ret []*v1.ClusterScalingSchedule, err error) {
-	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
-		ret = append(ret, m.(*v1.ClusterScalingSchedule))
-	})
-	return ret, err
-}
-
-// Get retrieves the ClusterScalingSchedule from the indexer for a given namespace and name.
-func (s clusterScalingScheduleNamespaceLister) Get(name string) (*v1.ClusterScalingSchedule, error) {
-	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
+// Get retrieves the ClusterScalingSchedule from the index for a given name.
+func (s *clusterScalingScheduleLister) Get(name string) (*v1.ClusterScalingSchedule, error) {
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/listers/zalando.org/v1/expansion_generated.go
+++ b/pkg/client/listers/zalando.org/v1/expansion_generated.go
@@ -22,10 +22,6 @@ package v1
 // ClusterScalingScheduleLister.
 type ClusterScalingScheduleListerExpansion interface{}
 
-// ClusterScalingScheduleNamespaceListerExpansion allows custom methods to be added to
-// ClusterScalingScheduleNamespaceLister.
-type ClusterScalingScheduleNamespaceListerExpansion interface{}
-
 // ScalingScheduleListerExpansion allows custom methods to be added to
 // ScalingScheduleLister.
 type ScalingScheduleListerExpansion interface{}


### PR DESCRIPTION
During #284 we set the ClusterScalingSchedule scope as `Cluster` but
just for kubebuilder. This flag has no effect in the generated clients.
It means the generated clients expect a namespace argument when handling
ClusterScalingSchedule resources. It works fine to list all of the
resources but makes it impossible to request a specific resource
defining its name.

This commit sets the `+genclient:nonNamespaced` flag for the CRD and
adds the regenerated clients. It does not affect any of the usages of the
clients in this codebase so far.

Also discussed [here](https://github.com/zalando-incubator/kube-metrics-adapter/pull/315#issuecomment-845825438).