### PR TITLE
Ignore ContainerResource metrics

### DIFF
--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -235,8 +235,8 @@ func ParseHPAMetrics(hpa *autoscalingv2.HorizontalPodAutoscaler) ([]*MetricConfi
 			}
 		case autoscalingv2.ExternalMetricSourceType:
 			typeName.Metric = metric.External.Metric
-		case autoscalingv2.ResourceMetricSourceType:
-			continue // kube-metrics-adapter does not collect resource metrics
+		case autoscalingv2.ResourceMetricSourceType, autoscalingv2.ContainerResourceMetricSourceType:
+			continue // kube-metrics-adapter does not collect resource or container resource metrics
 		}
 
 		config := &MetricConfig{


### PR DESCRIPTION
`ContainerResource` type metrics are supported as alpha feature in Kubernetes v1.20. They are implemented in the in-tree HPA, so we don't need/want to support them here similar to how we don't support `Resource` type metrics.

https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#container-resource-metrics