### PR TITLE
Remove HTTP collector check on identifier label

### DIFF
--- a/README.md
+++ b/README.md
@@ -650,9 +650,8 @@ spec:
         type: AverageValue
 ```
 
-The HTTP collector similar to the Pod Metrics collector. The metric name should always be `http`.
-This value is also used in the annotations to configure the metrics adapter to query the required
-target. The following configuration values are supported:
+The HTTP collector similar to the Pod Metrics collector. The following
+configuration values are supported:
 
 - `json-key` to specify the JSON path of the metric to be queried
 - `endpoint` the fully formed path to query for the metric. In the above example a Kubernetes _Service_

--- a/pkg/collector/http_collector.go
+++ b/pkg/collector/http_collector.go
@@ -18,7 +18,6 @@ const (
 	HTTPMetricNameLegacy      = "http"
 	HTTPEndpointAnnotationKey = "endpoint"
 	HTTPJsonPathAnnotationKey = "json-key"
-	identifierLabel           = "identifier"
 )
 
 type HTTPCollectorPlugin struct{}
@@ -52,9 +51,6 @@ func (p *HTTPCollectorPlugin) NewCollector(hpa *v2beta2.HorizontalPodAutoscaler,
 	collector.metricType = config.Type
 	if config.Metric.Selector == nil || config.Metric.Selector.MatchLabels == nil {
 		return nil, fmt.Errorf("no label selector specified for metric: %s", config.Metric.Name)
-	}
-	if _, ok := config.Metric.Selector.MatchLabels[identifierLabel]; !ok {
-		return nil, fmt.Errorf("%s is not specified as a label for metric %s", identifierLabel, config.Metric.Name)
 	}
 	collector.metric = config.Metric
 	var aggFunc httpmetrics.AggregatorFunc

--- a/pkg/collector/http_collector_test.go
+++ b/pkg/collector/http_collector_test.go
@@ -85,7 +85,7 @@ func makeTestHTTPCollectorConfig(endpoint, aggregator string) *MetricConfig {
 			Metric: v2beta2.MetricIdentifier{
 				Name: "test-metric",
 				Selector: &v1.LabelSelector{
-					MatchLabels: map[string]string{identifierLabel: "test-metric"},
+					MatchLabels: map[string]string{"type": HTTPJSONPathType},
 				},
 			},
 		},


### PR DESCRIPTION
This commit removes the logic that checks for an identifier label in the
http collector config. It also removes the documentation on the README
that mentions that the metric has to be in an old format, removed in
the #219.

Fixes #331

Signed-off-by: Jonathan Juares Beber <jonathanbeber@gmail.com>