### PR TITLE
Use labels for specifying Ingress/RouteGroup backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,9 @@ spec:
         name: myapp
       metric:
         name: requests-per-second
+        selector:
+          matchLabels:
+            backend: backend1 # optional backend
       target:
         averageValue: "10"
         type: AverageValue
@@ -382,6 +385,9 @@ spec:
         name: myapp
       metric:
         name: requests-per-second
+        selector:
+          matchLabels:
+            backend: backend1 # optional backend
       target:
         averageValue: "10"
         type: AverageValue
@@ -389,15 +395,13 @@ spec:
 
 ### Metric weighting based on backend
 
-Skipper supports sending traffic to different backend based on annotations
-present on the `Ingress` object, or weights on the RouteGroup backends. When
-the metric name is specified without a backend as `requests-per-second` then
-the number of replicas will be calculated based on the full traffic served by
-that ingress/routegroup.  If however only the traffic being routed to a
-specific backend should be used then the backend name can be specified as a
-metric name like `requests-per-second,backend1` which would return the
-requests-per-second being sent to the `backend1`. The ingress annotation where
-the backend weights can be obtained can be specified through the flag
+Skipper supports sending traffic to different backends based on annotations
+present on the `Ingress` object, or weights on the RouteGroup backends. By
+default the number of replicas will be calculated based on the full traffic
+served by that ingress/routegroup.  If however only the traffic being routed to
+a specific backend should be used then the backend name can be specified via
+the `backend` label under `matchLabels` for the metric.  The ingress annotation
+where the backend weights can be obtained can be specified through the flag
 `--skipper-backends-annotation`.
 
 ## InfluxDB collector

--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -247,9 +247,15 @@ func ParseHPAMetrics(hpa *autoscalingv2.HorizontalPodAutoscaler) ([]*MetricConfi
 		}
 
 		if metric.Type == autoscalingv2.ExternalMetricSourceType &&
-			metric.External.Metric.Selector != nil &&
-			metric.External.Metric.Selector.MatchLabels != nil {
+			metric.External.Metric.Selector != nil {
 			for k, v := range metric.External.Metric.Selector.MatchLabels {
+				config.Config[k] = v
+			}
+		}
+
+		if metric.Type == autoscalingv2.ObjectMetricSourceType &&
+			metric.Object.Metric.Selector != nil {
+			for k, v := range metric.Object.Metric.Selector.MatchLabels {
 				config.Config[k] = v
 			}
 		}

--- a/pkg/collector/skipper_collector.go
+++ b/pkg/collector/skipper_collector.go
@@ -53,6 +53,8 @@ func (c *SkipperCollectorPlugin) NewCollector(hpa *autoscalingv2.HorizontalPodAu
 	if strings.HasPrefix(config.Metric.Name, rpsMetricName) {
 		backend, ok := config.Config["backend"]
 		if !ok {
+			// TODO: remove the deprecated way of specifying
+			// optional backend at a later point in time.
 			if len(config.Metric.Name) > len(rpsMetricName) {
 				metricNameParts := strings.Split(config.Metric.Name, rpsMetricBackendSeparator)
 				if len(metricNameParts) == 2 {

--- a/pkg/collector/skipper_collector.go
+++ b/pkg/collector/skipper_collector.go
@@ -51,11 +51,13 @@ func NewSkipperCollectorPlugin(client kubernetes.Interface, rgClient rginterface
 // NewCollector initializes a new skipper collector from the specified HPA.
 func (c *SkipperCollectorPlugin) NewCollector(hpa *autoscalingv2.HorizontalPodAutoscaler, config *MetricConfig, interval time.Duration) (Collector, error) {
 	if strings.HasPrefix(config.Metric.Name, rpsMetricName) {
-		backend := ""
-		if len(config.Metric.Name) > len(rpsMetricName) {
-			metricNameParts := strings.Split(config.Metric.Name, rpsMetricBackendSeparator)
-			if len(metricNameParts) == 2 {
-				backend = metricNameParts[1]
+		backend, ok := config.Config["backend"]
+		if !ok {
+			if len(config.Metric.Name) > len(rpsMetricName) {
+				metricNameParts := strings.Split(config.Metric.Name, rpsMetricBackendSeparator)
+				if len(metricNameParts) == 2 {
+					backend = metricNameParts[1]
+				}
 			}
 		}
 		return NewSkipperCollector(c.client, c.rgClient, c.plugin, hpa, config, interval, c.backendAnnotations, backend)


### PR DESCRIPTION
When users wanted to scaled based on the RPS of a single backend for a traffic weighted Ingress/RouteGroup they could define the backend name as part of the metric name e.g. `requests-per-second,<backend>`. This "hack" of making the backend part of the metric name was introduced back when we used `autoscaling/v2beta1` when labels were not supported on Object type metrics.

Switch to use the match labels for defining the `backend` which is possible with `autoscaling/v2beta2`.

```yaml
metric:
  name: requests-per-second
  selector:
    matchLabels:
      backend: backend1 # optional backend
```

The previous deprecated format looked like this:

```yaml
metric:
  name: requests-per-second,backend1
```