### PR TITLE
Use labels hash in the custom metrics store and metrics store :nail_care: 

### DIFF
--- a/pkg/provider/hpa.go
+++ b/pkg/provider/hpa.go
@@ -269,7 +269,7 @@ func (p *HPAProvider) collectMetrics(ctx context.Context) {
 
 // GetMetricByName gets a single metric by name.
 func (p *HPAProvider) GetMetricByName(name types.NamespacedName, info provider.CustomMetricInfo, metricSelector labels.Selector) (*custom_metrics.MetricValue, error) {
-	metric := p.metricStore.GetMetricsByName(name, info)
+	metric := p.metricStore.GetMetricsByName(name, info, metricSelector)
 	if metric == nil {
 		return nil, provider.NewMetricNotFoundForError(info.GroupResource, info.Metric, name.Name)
 	}

--- a/pkg/provider/hpa.go
+++ b/pkg/provider/hpa.go
@@ -279,7 +279,7 @@ func (p *HPAProvider) GetMetricByName(name types.NamespacedName, info provider.C
 // GetMetricBySelector returns metrics for namespaced resources by
 // label selector.
 func (p *HPAProvider) GetMetricBySelector(namespace string, selector labels.Selector, info provider.CustomMetricInfo, metricSelector labels.Selector) (*custom_metrics.MetricValueList, error) {
-	return p.metricStore.GetMetricsBySelector(namespace, selector, info), nil
+	return p.metricStore.GetMetricsBySelector(objectNamespace(namespace), selector, info), nil
 }
 
 // ListAllMetrics list all available metrics from the provicer.
@@ -288,7 +288,7 @@ func (p *HPAProvider) ListAllMetrics() []provider.CustomMetricInfo {
 }
 
 func (p *HPAProvider) GetExternalMetric(namespace string, metricSelector labels.Selector, info provider.ExternalMetricInfo) (*external_metrics.ExternalMetricValueList, error) {
-	return p.metricStore.GetExternalMetric(namespace, metricSelector, info)
+	return p.metricStore.GetExternalMetric(objectNamespace(namespace), metricSelector, info)
 }
 
 func (p *HPAProvider) ListAllExternalMetrics() []provider.ExternalMetricInfo {

--- a/pkg/provider/metrics_store_test.go
+++ b/pkg/provider/metrics_store_test.go
@@ -498,10 +498,10 @@ func TestInternalMetricStorage(t *testing.T) {
 			metric := metricsStore.GetMetricsByName(tc.byName.name, tc.byName.info, tc.byLabel.selector)
 			if tc.expectedFound {
 				require.Equal(t, tc.insert.Custom, *metric)
-				metrics := metricsStore.GetMetricsBySelector(tc.byLabel.namespace, tc.byLabel.selector, tc.byLabel.info)
+				metrics := metricsStore.GetMetricsBySelector(objectNamespace(tc.byLabel.namespace), tc.byLabel.selector, tc.byLabel.info)
 				require.Equal(t, tc.insert.Custom, metrics.Items[0])
 			} else {
-				metrics := metricsStore.GetMetricsBySelector(tc.byLabel.namespace, tc.byLabel.selector, tc.byLabel.info)
+				metrics := metricsStore.GetMetricsBySelector(objectNamespace(tc.byLabel.namespace), tc.byLabel.selector, tc.byLabel.info)
 				require.Len(t, metrics.Items, 0)
 			}
 		})
@@ -672,7 +672,7 @@ func TestMultipleMetricValues(t *testing.T) {
 				require.Equal(t, insert.Custom, *metric)
 
 				// Get the metric by label
-				metrics := metricsStore.GetMetricsBySelector(tc.byLabel.namespace, tc.byLabel.selector, tc.byLabel.info)
+				metrics := metricsStore.GetMetricsBySelector(objectNamespace(tc.byLabel.namespace), tc.byLabel.selector, tc.byLabel.info)
 				require.Equal(t, insert.Custom, metrics.Items[0])
 			}
 
@@ -800,7 +800,7 @@ func TestCustomMetricsStorageErrors(t *testing.T) {
 			metric := metricsStore.GetMetricsByName(tc.byName.name, tc.byName.info, tc.byLabel.selector)
 			require.Nil(t, metric)
 
-			metrics := metricsStore.GetMetricsBySelector(tc.byLabel.namespace, tc.byLabel.selector, tc.byLabel.info)
+			metrics := metricsStore.GetMetricsBySelector(objectNamespace(tc.byLabel.namespace), tc.byLabel.selector, tc.byLabel.info)
 			require.Equal(t, &custom_metrics.MetricValueList{}, metrics)
 
 		})
@@ -990,7 +990,7 @@ func TestExternalMetricStorage(t *testing.T) {
 			require.Equal(t, tc.list, metricInfos[0])
 
 			// Get the metric by name
-			metrics, err := metricsStore.GetExternalMetric(tc.get.namespace, tc.get.selector, tc.get.info)
+			metrics, err := metricsStore.GetExternalMetric(objectNamespace(tc.get.namespace), tc.get.selector, tc.get.info)
 			require.NoError(t, err)
 			require.Equal(t, tc.insert.External, metrics.Items[0])
 
@@ -1158,7 +1158,7 @@ func TestMultipleExternalMetricStorage(t *testing.T) {
 			}
 
 			// Get the metric by name
-			metrics, err := metricsStore.GetExternalMetric(tc.get.namespace, tc.get.selector, tc.get.info)
+			metrics, err := metricsStore.GetExternalMetric(objectNamespace(tc.get.namespace), tc.get.selector, tc.get.info)
 			require.NoError(t, err)
 			require.Len(t, metrics.Items, 1)
 			require.Contains(t, metrics.Items, tc.insert[tc.expectedIdx].External)


### PR DESCRIPTION
#### Use labels hash in the custom metrics store 

The current implementation of the metrics store for custom metrics uses
just the object name as key. When scenarios where two HPAs reference the
same object but have different metric calculation (e.g. ingresses with
different weights), kube-metrics-adapter calculates the two metrics but
always overrides one of the metrics when saving it to the store.

This commit implements the use of a labels hash in the custom metrics
store. This way, metrics are identified not just by the referenced
object, but also by its selectors.

#### Define stronger types for metrics store 

The metrics store, both the custom and external one, make heavy usage of
maps of strings to strings. This leads to a presumable confusing or at
least hard to read codebase.

This commit tries to increase readability and maintainability of the
metric stores by using custom types. This commit has no effect in
performance or functionality, it's pure aesthetics.