### PR TITLE
Use cdp-runtime for build

### DIFF
--- a/delivery.yaml
+++ b/delivery.yaml
@@ -1,7 +1,9 @@
 version: "2017-09-20"
 pipeline:
 - id: build
-  overlay: ci/golang
+  vm_config:
+    type: linux
+    image: "cdp-runtime/go"
   cache:
     paths:
     - /go/pkg/mod       # pkg cache for Go modules


### PR DESCRIPTION
CDP is pushing a new concept called `runtime`s for setting up the build environment. It's similar to `overlay`s but is implemented slightly different (as a docker container as opposed to a tar extracting the content on the VM filesystem).

The runtime and overlay for go are pretty much identical in terms of tools installed etc.