### PR TITLE
adding nodeSelector + tolerations + affinity + priorityClassName + po…

### DIFF
--- a/docs/helm/Chart.yaml
+++ b/docs/helm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: kube-metrics-adapter
-version: 0.1.11
+version: 0.1.18
 description: kube-metrics-adapter helm chart
 home: https://github.com/zalando-incubator/kube-metrics-adapter
 maintainers:

--- a/docs/helm/templates/deployment.yaml
+++ b/docs/helm/templates/deployment.yaml
@@ -16,8 +16,23 @@ spec:
       labels:
         application: kube-metrics-adapter
         version: {{ .Values.registry.imageTag }}
+      {{- if .Values.podAnnotations }}
+      annotations: {{- toYaml .Values.podAnnotations | nindent 8 }}
+      {{- end }}
     spec:
       serviceAccountName: kube-metrics-adapter
+    {{- if .Values.nodeSelector }}
+      nodeSelector: {{ toYaml .Values.nodeSelector | nindent 8 }}
+    {{- end }}
+    {{- if .Values.tolerations }}
+      tolerations: {{ toYaml .Values.tolerations | nindent 8 }}
+    {{- end }}
+    {{- if .Values.affinity }}
+      affinity: {{ toYaml .Values.affinity | nindent 8 }}
+    {{- end }}
+    {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName | quote }}
+    {{- end }}
       containers:
         - name: kube-metrics-adapter
           image: {{ .Values.registry.image}}:{{ .Values.registry.imageTag }}

--- a/docs/helm/values.yaml
+++ b/docs/helm/values.yaml
@@ -95,3 +95,14 @@ resources:
 
 scalingSchedule:
   enabled: false
+
+nodeSelector:
+  kubernetes.io/os: linux
+
+tolerations: []
+
+affinity: {}
+
+priorityClassName: ""
+
+podAnnotations: {}


### PR DESCRIPTION
…dAnnotations to helm chart

Signed-off-by: Olivier Schiavo <olivier.schiavo@wengo.com>

# One-line summary

Some useful parameters added to the helm template

## Description

nodeSelector
tolerations
affinity
priorityClassName
podAnnotations

Are often useful in helm charts, for example podAnnotations allow to use kube2iam, nodeSelector allows to select a specific pool of nodes ( ie: running linux, arch x86_64, .. ) etc




## Types of Changes

- New feature 

The new parameters are completely optional and will not change anything for those who do not need them.

## Tasks

I have tested the changes on our eks clusters and the state is "works for me".
The changes are minimal, in order to better support helm it would be very nice if you could configure github pages to provide a helm repo. Thanks for all this work anyway, this is the only working and supported implementation of a metrics adapters I know of for EKS. Amazingly aws does not support anymore its own version.

## Review

There is not much documentation on the helm chart, maybe just a CHANGELOG will be enough?


## Deployment Notes
The patch does not affect the go code, it will just allow helm users to have 5 more parameters.
