### PR TITLE
Limit ingress support to only networking.k8s.io/v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ box so users don't have to define those manually.
 
 | Metric | Description | Type | Kind | K8s Versions |
 | ----------- | -------------- | ------ | ---- | ---- |
-| `requests-per-second` | Scale based on requests per second for a certain ingress or routegroup. | Object | `Ingress`, `RouteGroup` | `>=1.14` |
+| `requests-per-second` | Scale based on requests per second for a certain ingress or routegroup. | Object | `Ingress`, `RouteGroup` | `>=1.19` |
 
 ### Example
 

--- a/docs/helm/templates/rbac.yaml
+++ b/docs/helm/templates/rbac.yaml
@@ -60,7 +60,7 @@ rules:
   verbs:
   - get
 - apiGroups:
-  - extensions
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/docs/rbac.yaml
+++ b/docs/rbac.yaml
@@ -67,7 +67,6 @@ rules:
 # only relevant if running with the flag:
 # --skipper-ingress-metrics
 - apiGroups:
-  - extensions
   - networking.k8s.io
   resources:
   - ingresses

--- a/example/deploy/hpa.yaml
+++ b/example/deploy/hpa.yaml
@@ -39,7 +39,7 @@ spec:
   - type: Object
     object:
       describedObject:
-        apiVersion: extensions/v1beta1
+        apiVersion: networking.k8s.io/v1
         kind: Ingress
         name: custom-metrics-consumer
       metric:

--- a/example/deploy/ingress.yaml
+++ b/example/deploy/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: custom-metrics-consumer

--- a/pkg/collector/skipper_collector.go
+++ b/pkg/collector/skipper_collector.go
@@ -162,7 +162,7 @@ func (c *SkipperCollector) getCollector(ctx context.Context) (Collector, error) 
 	var backendWeight float64
 	switch c.objectReference.Kind {
 	case "Ingress":
-		ingress, err := c.client.NetworkingV1beta1().Ingresses(c.objectReference.Namespace).Get(ctx, c.objectReference.Name, metav1.GetOptions{})
+		ingress, err := c.client.NetworkingV1().Ingresses(c.objectReference.Namespace).Get(ctx, c.objectReference.Name, metav1.GetOptions{})
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/provider/metric_store.go
+++ b/pkg/provider/metric_store.go
@@ -87,8 +87,7 @@ func (s *MetricStore) insertCustomMetric(value custom_metrics.MetricValue) {
 			Resource: "pods",
 		}
 	case "Ingress":
-		// group can be either `extensions` or `networking.k8s.io`
-		group := "extensions"
+		group := "networking.k8s.io"
 		gv, err := schema.ParseGroupVersion(value.DescribedObject.APIVersion)
 		if err == nil {
 			group = gv.Group

--- a/pkg/provider/metric_store_test.go
+++ b/pkg/provider/metric_store_test.go
@@ -320,7 +320,7 @@ func TestInternalMetricStorage(t *testing.T) {
 					DescribedObject: custom_metrics.ObjectReference{
 						Name:       "metricObject",
 						Kind:       "Ingress",
-						APIVersion: "extensions/v1beta1",
+						APIVersion: "networking.k8s.io/v1",
 					},
 				},
 			},
@@ -328,7 +328,7 @@ func TestInternalMetricStorage(t *testing.T) {
 			list: []provider.CustomMetricInfo{
 				{
 					GroupResource: schema.GroupResource{
-						Group:    "extensions",
+						Group:    "networking.k8s.io",
 						Resource: "ingresses",
 					},
 					Namespaced: false,
@@ -342,7 +342,7 @@ func TestInternalMetricStorage(t *testing.T) {
 				name: types.NamespacedName{Name: "metricObject", Namespace: ""},
 				info: provider.CustomMetricInfo{
 					GroupResource: schema.GroupResource{
-						Group:    "extensions",
+						Group:    "networking.k8s.io",
 						Resource: "ingresses",
 					},
 					Namespaced: false,
@@ -358,7 +358,7 @@ func TestInternalMetricStorage(t *testing.T) {
 				selector:  labels.SelectorFromSet(labels.Set{"select_key": "select_value"}),
 				info: provider.CustomMetricInfo{
 					GroupResource: schema.GroupResource{
-						Group:    "extensions",
+						Group:    "networking.k8s.io",
 						Resource: "ingresses",
 					},
 					Namespaced: false,
@@ -376,7 +376,7 @@ func TestInternalMetricStorage(t *testing.T) {
 					DescribedObject: custom_metrics.ObjectReference{
 						Name:       "metricObject",
 						Kind:       "Ingress",
-						APIVersion: "extensions/v1beta1",
+						APIVersion: "networking.k8s.io/v1",
 					},
 				},
 			},
@@ -384,7 +384,7 @@ func TestInternalMetricStorage(t *testing.T) {
 			list: []provider.CustomMetricInfo{
 				{
 					GroupResource: schema.GroupResource{
-						Group:    "extensions",
+						Group:    "networking.k8s.io",
 						Resource: "ingresses",
 					},
 					Namespaced: false,
@@ -398,7 +398,7 @@ func TestInternalMetricStorage(t *testing.T) {
 				name: types.NamespacedName{Name: "metricObject", Namespace: ""},
 				info: provider.CustomMetricInfo{
 					GroupResource: schema.GroupResource{
-						Group:    "extensions",
+						Group:    "networking.k8s.io",
 						Resource: "ingresses",
 					},
 					Namespaced: false,
@@ -414,7 +414,7 @@ func TestInternalMetricStorage(t *testing.T) {
 				selector:  labels.Everything(),
 				info: provider.CustomMetricInfo{
 					GroupResource: schema.GroupResource{
-						Group:    "extensions",
+						Group:    "networking.k8s.io",
 						Resource: "ingresses",
 					},
 					Namespaced: false,
@@ -433,7 +433,7 @@ func TestInternalMetricStorage(t *testing.T) {
 						Name:       "metricObject",
 						Namespace:  "right",
 						Kind:       "Ingress",
-						APIVersion: "extensions/v1beta1",
+						APIVersion: "networking.k8s.io/v1",
 					},
 				},
 			},
@@ -441,7 +441,7 @@ func TestInternalMetricStorage(t *testing.T) {
 			list: []provider.CustomMetricInfo{
 				{
 					GroupResource: schema.GroupResource{
-						Group:    "extensions",
+						Group:    "networking.k8s.io",
 						Resource: "ingresses",
 					},
 					Namespaced: true,
@@ -455,7 +455,7 @@ func TestInternalMetricStorage(t *testing.T) {
 				name: types.NamespacedName{Name: "metricObject", Namespace: "wrong"},
 				info: provider.CustomMetricInfo{
 					GroupResource: schema.GroupResource{
-						Group:    "extensions",
+						Group:    "networking.k8s.io",
 						Resource: "ingresses",
 					},
 					Namespaced: true,
@@ -471,7 +471,7 @@ func TestInternalMetricStorage(t *testing.T) {
 				selector:  labels.Everything(),
 				info: provider.CustomMetricInfo{
 					GroupResource: schema.GroupResource{
-						Group:    "extensions",
+						Group:    "networking.k8s.io",
 						Resource: "ingresses",
 					},
 					Namespaced: true,
@@ -535,7 +535,7 @@ func TestMultipleMetricValues(t *testing.T) {
 						DescribedObject: custom_metrics.ObjectReference{
 							Name:       "metricObject",
 							Kind:       "Ingress",
-							APIVersion: "extensions/v1beta1",
+							APIVersion: "networking.k8s.io/v1",
 						},
 					},
 				},
@@ -547,7 +547,7 @@ func TestMultipleMetricValues(t *testing.T) {
 						DescribedObject: custom_metrics.ObjectReference{
 							Name:       "metricObject",
 							Kind:       "Ingress",
-							APIVersion: "extensions/v1beta1",
+							APIVersion: "networking.k8s.io/v1",
 						},
 					},
 				},
@@ -555,7 +555,7 @@ func TestMultipleMetricValues(t *testing.T) {
 			list: []provider.CustomMetricInfo{
 				{
 					GroupResource: schema.GroupResource{
-						Group:    "extensions",
+						Group:    "networking.k8s.io",
 						Resource: "ingresses",
 					},
 					Namespaced: false,
@@ -569,7 +569,7 @@ func TestMultipleMetricValues(t *testing.T) {
 				name: types.NamespacedName{Name: "metricObject", Namespace: ""},
 				info: provider.CustomMetricInfo{
 					GroupResource: schema.GroupResource{
-						Group:    "extensions",
+						Group:    "networking.k8s.io",
 						Resource: "ingresses",
 					},
 					Namespaced: false,
@@ -585,7 +585,7 @@ func TestMultipleMetricValues(t *testing.T) {
 				selector:  labels.Everything(),
 				info: provider.CustomMetricInfo{
 					GroupResource: schema.GroupResource{
-						Group:    "extensions",
+						Group:    "networking.k8s.io",
 						Resource: "ingresses",
 					},
 					Namespaced: false,
@@ -831,7 +831,7 @@ func TestCustomMetricsStorageErrors(t *testing.T) {
 							Name:       "metricObject",
 							Namespace:  "default",
 							Kind:       "Ingress",
-							APIVersion: "extensions/vbeta1",
+							APIVersion: "networking.k8s.io/v1",
 						},
 					},
 				},


### PR DESCRIPTION
Given the deprecation of `extensions/v1beta1`, remove it from Ingress possibilities.