### PR TITLE
Update scalingschedule config

### DIFF
--- a/docs/cluster_scaling_schedules_crd.yaml
+++ b/docs/cluster_scaling_schedules_crd.yaml
@@ -55,8 +55,8 @@ spec:
                       format: date-time
                       type: string
                     durationMinutes:
-                      description: The duration in minutes that the configured value
-                        will be returned for the defined schedule.
+                      description: The duration in minutes (default 0) that the configured
+                        value will be returned for the defined schedule.
                       type: integer
                     endDate:
                       description: Defines the ending date of a OneTime schedule.
@@ -95,7 +95,6 @@ spec:
                           type: string
                       required:
                       - days
-                      - endTime
                       - startTime
                       - timezone
                       type: object
@@ -113,7 +112,6 @@ spec:
                       format: int64
                       type: integer
                   required:
-                  - durationMinutes
                   - type
                   - value
                   type: object

--- a/docs/cluster_scaling_schedules_crd.yaml
+++ b/docs/cluster_scaling_schedules_crd.yaml
@@ -58,6 +58,11 @@ spec:
                       description: The duration in minutes that the configured value
                         will be returned for the defined schedule.
                       type: integer
+                    endDate:
+                      description: Defines the ending date of a OneTime schedule.
+                        It must be a RFC3339 formated date.
+                      format: date-time
+                      type: string
                     period:
                       description: Defines the details of a Repeating schedule.
                       properties:
@@ -76,6 +81,10 @@ spec:
                             - Sat
                             type: string
                           type: array
+                        endTime:
+                          description: The endTime has the format HH:MM
+                          pattern: (([0-1][0-9])|([2][0-3])):([0-5][0-9])
+                          type: string
                         startTime:
                           description: The startTime has the format HH:MM
                           pattern: (([0-1][0-9])|([2][0-3])):([0-5][0-9])
@@ -86,6 +95,7 @@ spec:
                           type: string
                       required:
                       - days
+                      - endTime
                       - startTime
                       - timezone
                       type: object

--- a/docs/scaling_schedules_crd.yaml
+++ b/docs/scaling_schedules_crd.yaml
@@ -55,8 +55,8 @@ spec:
                       format: date-time
                       type: string
                     durationMinutes:
-                      description: The duration in minutes that the configured value
-                        will be returned for the defined schedule.
+                      description: The duration in minutes (default 0) that the configured
+                        value will be returned for the defined schedule.
                       type: integer
                     endDate:
                       description: Defines the ending date of a OneTime schedule.
@@ -95,7 +95,6 @@ spec:
                           type: string
                       required:
                       - days
-                      - endTime
                       - startTime
                       - timezone
                       type: object
@@ -113,7 +112,6 @@ spec:
                       format: int64
                       type: integer
                   required:
-                  - durationMinutes
                   - type
                   - value
                   type: object

--- a/docs/scaling_schedules_crd.yaml
+++ b/docs/scaling_schedules_crd.yaml
@@ -58,6 +58,11 @@ spec:
                       description: The duration in minutes that the configured value
                         will be returned for the defined schedule.
                       type: integer
+                    endDate:
+                      description: Defines the ending date of a OneTime schedule.
+                        It must be a RFC3339 formated date.
+                      format: date-time
+                      type: string
                     period:
                       description: Defines the details of a Repeating schedule.
                       properties:
@@ -76,6 +81,10 @@ spec:
                             - Sat
                             type: string
                           type: array
+                        endTime:
+                          description: The endTime has the format HH:MM
+                          pattern: (([0-1][0-9])|([2][0-3])):([0-5][0-9])
+                          type: string
                         startTime:
                           description: The startTime has the format HH:MM
                           pattern: (([0-1][0-9])|([2][0-3])):([0-5][0-9])
@@ -86,6 +95,7 @@ spec:
                           type: string
                       required:
                       - days
+                      - endTime
                       - startTime
                       - timezone
                       type: object

--- a/pkg/apis/zalando.org/v1/types.go
+++ b/pkg/apis/zalando.org/v1/types.go
@@ -65,8 +65,9 @@ type Schedule struct {
 	// a RFC3339 formated date.
 	// +optional
 	EndDate *ScheduleDate `json:"endDate,omitempty"`
-	// The duration in minutes that the configured value will be
+	// The duration in minutes (default 0) that the configured value will be
 	// returned for the defined schedule.
+	// +optional
 	DurationMinutes int `json:"durationMinutes"`
 	// The metric value that will be returned for the defined schedule.
 	Value int64 `json:"value"`
@@ -96,6 +97,7 @@ type SchedulePeriod struct {
 	StartTime string `json:"startTime"`
 	// The endTime has the format HH:MM
 	// +kubebuilder:validation:Pattern="(([0-1][0-9])|([2][0-3])):([0-5][0-9])"
+	// +optional
 	EndTime string `json:"endTime"`
 	// The days that this schedule will be active.
 	Days []ScheduleDay `json:"days"`

--- a/pkg/apis/zalando.org/v1/types.go
+++ b/pkg/apis/zalando.org/v1/types.go
@@ -61,6 +61,10 @@ type Schedule struct {
 	// be a RFC3339 formated date.
 	// +optional
 	Date *ScheduleDate `json:"date,omitempty"`
+	// Defines the ending date of a OneTime schedule. It must be
+	// a RFC3339 formated date.
+	// +optional
+	EndDate *ScheduleDate `json:"endDate,omitempty"`
 	// The duration in minutes that the configured value will be
 	// returned for the defined schedule.
 	DurationMinutes int `json:"durationMinutes"`
@@ -90,6 +94,9 @@ type SchedulePeriod struct {
 	// The startTime has the format HH:MM
 	// +kubebuilder:validation:Pattern="(([0-1][0-9])|([2][0-3])):([0-5][0-9])"
 	StartTime string `json:"startTime"`
+	// The endTime has the format HH:MM
+	// +kubebuilder:validation:Pattern="(([0-1][0-9])|([2][0-3])):([0-5][0-9])"
+	EndTime string `json:"endTime"`
 	// The days that this schedule will be active.
 	Days []ScheduleDay `json:"days"`
 	// The location name corresponding to a file in the IANA

--- a/pkg/apis/zalando.org/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/zalando.org/v1/zz_generated.deepcopy.go
@@ -186,6 +186,11 @@ func (in *Schedule) DeepCopyInto(out *Schedule) {
 		*out = new(ScheduleDate)
 		**out = **in
 	}
+	if in.EndDate != nil {
+		in, out := &in.EndDate, &out.EndDate
+		*out = new(ScheduleDate)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/collector/scaling_schedule_collector.go
+++ b/pkg/collector/scaling_schedule_collector.go
@@ -294,8 +294,10 @@ func calculateMetrics(spec v1.ScalingScheduleSpec, defaultScalingWindow time.Dur
 						location,
 					)
 
-					// first check if an end time is provided
-					if schedule.Period.EndTime != "" {
+					// If no end time was provided, set it to equal the start time
+					if schedule.Period.EndTime == "" {
+						scheduledEndTime = scheduledTime
+					} else {
 						parsedEndTime, err := time.Parse(hourColonMinuteLayout, schedule.Period.EndTime)
 						if err != nil {
 							return nil, ErrInvalidScheduleDate
@@ -362,9 +364,6 @@ func valueForEntry(timestamp time.Time, startTime time.Time, entryDuration time.
 
 	// Use either the defined end time/date or the start time/date + the
 	// duration, whichever is longer.
-	fmt.Println("-----")
-	fmt.Printf("starttime: %v\n", startTime)
-	fmt.Printf("end time: %v\n", scheduledEndTime)
 	if startTime.Add(entryDuration).Before(scheduledEndTime) {
 		endTime = scheduledEndTime
 	} else {

--- a/pkg/collector/scaling_schedule_collector_test.go
+++ b/pkg/collector/scaling_schedule_collector_test.go
@@ -21,6 +21,7 @@ const (
 type schedule struct {
 	kind      string
 	date      string
+	endDate   string
 	startTime string
 	days      []v1.ScheduleDay
 	timezone  string
@@ -70,6 +71,19 @@ func TestScalingScheduleCollector(t *testing.T) {
 					date:     nowTime.Add(-time.Minute * 10).Format(time.RFC3339),
 					kind:     "OneTime",
 					duration: 15,
+					value:    100,
+				},
+			},
+			expectedValue: 100,
+		},
+		{
+			msg: "Return 100 - utilise end date instead of start date + duration for one time config",
+			schedules: []schedule{
+				{
+					date:     nowTime.Add(-2 * time.Hour).Format(time.RFC3339),
+					kind:     "OneTime",
+					duration: 60,
+					endDate:  nowTime.Add(1 * time.Hour).Format(time.RFC3339),
 					value:    100,
 				},
 			},
@@ -745,15 +759,18 @@ func newClusterMockStoreFirstRun(name string, scalingWindowDurationMinutes *int6
 	}
 }
 
+// comment DEBUG
 func getSchedules(schedules []schedule) (result []v1.Schedule) {
 	for _, schedule := range schedules {
 		switch schedule.kind {
 		case string(v1.OneTimeSchedule):
 			date := v1.ScheduleDate(schedule.date)
+			endDate := v1.ScheduleDate(schedule.endDate)
 			result = append(result,
 				v1.Schedule{
 					Type:            v1.OneTimeSchedule,
 					Date:            &date,
+					EndDate:         &endDate,
 					DurationMinutes: schedule.duration,
 					Value:           schedule.value,
 				},


### PR DESCRIPTION
# Add end time/date options for (cluster) scaling schedules. 

## Description
The added end time/date options adds greater flexibility for (cluster) scaling schedules as this offers an alternative to the current start time/date + duration (in minutes) configuration - which is not easily readable when longer durations are present. The end time/date is an optional field which will only override the schedule duration if it is further in the future. Likewise, the duration field will override the scheduled end date if it is set to end after the scheduled end date. In short: the latest ending time/date will be given priority. 
