### PR TITLE
Update HPA to autoscaling/v2 apiVersion

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,7 @@ for Kubernetes, this project aims to support the latest three minor releases of
 Kubernetes.
 
 The default supported API is `autoscaling/v2` (available since `v1.23`).
-This API MUST be available in the cluster which is the default. However for
-GKE, this requires GKE v1.23+.
+This API MUST be available in the cluster which is the default.
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Here's an example of a `HorizontalPodAutoscaler` resource configured to get
 `requests-per-second` metrics from each pod of the deployment `myapp`.
 
 ```yaml
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: myapp-hpa
@@ -54,10 +54,9 @@ policy](https://kubernetes.io/docs/setup/release/version-skew-policy/) offered
 for Kubernetes, this project aims to support the latest three minor releases of
 Kubernetes.
 
-The default supported API is `autoscaling/v2beta2` (available since `v1.12`).
+The default supported API is `autoscaling/v2` (available since `v1.23`).
 This API MUST be available in the cluster which is the default. However for
-GKE, this requires GKE v1.15.7 according to this [GKE
-Issue](https://issuetracker.google.com/issues/135624588).
+GKE, this requires GKE v1.23+.
 
 ## Building
 
@@ -99,7 +98,7 @@ This is an example of using the pod collector to collect metrics from a json
 metrics endpoint of each pod matched by the HPA.
 
 ```yaml
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: myapp-hpa
@@ -219,7 +218,7 @@ with the result of the query.
 This allows having multiple prometheus queries associated with a single HPA.
 
 ```yaml
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: myapp-hpa
@@ -331,7 +330,7 @@ This is an example of an HPA that will scale based on `requests-per-second` for
 an ingress called `myapp`.
 
 ```yaml
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: myapp-hpa
@@ -365,7 +364,7 @@ This is an example of an HPA that will scale based on `requests-per-second` for
 a routegroup called `myapp`.
 
 ```yaml
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: myapp-hpa
@@ -426,7 +425,7 @@ the query name which will be associated with the result of the query.  This
 allows having multiple flux queries associated with a single HPA.
 
 ```yaml
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: myapp-hpa
@@ -514,7 +513,7 @@ This is an example of an HPA that will scale based on the length of an SQS
 queue.
 
 ```yaml
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: myapp-hpa
@@ -566,7 +565,7 @@ This is an example of an HPA that will scale based on the specified value
 exposed by a ZMON check with id `1234`.
 
 ```yaml
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: myapp-hpa
@@ -663,7 +662,7 @@ This is an example of using the HTTP collector to collect metrics from a json
 metrics endpoint specified in the annotations.
 
 ```yaml
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: myapp-hpa
@@ -830,7 +829,7 @@ An HPA can reference the deployed `ClusterScalingSchedule` object as
 this example:
 
 ```yaml
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: "myapp-hpa"

--- a/pkg/annotations/parser.go
+++ b/pkg/annotations/parser.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"time"
 
-	autoscalingv2 "k8s.io/api/autoscaling/v2beta2"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 )
 
 const (

--- a/pkg/annotations/parser_test.go
+++ b/pkg/annotations/parser_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	autoscalingv2 "k8s.io/api/autoscaling/v2beta2"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 )
 
 func TestParser(t *testing.T) {

--- a/pkg/collector/aws_collector.go
+++ b/pkg/collector/aws_collector.go
@@ -9,7 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sqs"
 	"github.com/aws/aws-sdk-go/service/sqs/sqsiface"
-	autoscalingv2 "k8s.io/api/autoscaling/v2beta2"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/metrics/pkg/apis/external_metrics"

--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -6,7 +6,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"github.com/zalando-incubator/kube-metrics-adapter/pkg/annotations"
-	autoscalingv2 "k8s.io/api/autoscaling/v2beta2"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/metrics/pkg/apis/custom_metrics"
 	"k8s.io/metrics/pkg/apis/external_metrics"
 )

--- a/pkg/collector/collector_test.go
+++ b/pkg/collector/collector_test.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	autoscalingv2 "k8s.io/api/autoscaling/v2beta2"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/pkg/collector/http_collector.go
+++ b/pkg/collector/http_collector.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/zalando-incubator/kube-metrics-adapter/pkg/collector/httpmetrics"
 
-	v2 "k8s.io/api/autoscaling/v2"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/metrics/pkg/apis/external_metrics"
@@ -26,7 +26,7 @@ func NewHTTPCollectorPlugin() (*HTTPCollectorPlugin, error) {
 	return &HTTPCollectorPlugin{}, nil
 }
 
-func (p *HTTPCollectorPlugin) NewCollector(hpa *v2.HorizontalPodAutoscaler, config *MetricConfig, interval time.Duration) (Collector, error) {
+func (p *HTTPCollectorPlugin) NewCollector(hpa *autoscalingv2.HorizontalPodAutoscaler, config *MetricConfig, interval time.Duration) (Collector, error) {
 	collector := &HTTPCollector{
 		namespace: hpa.Namespace,
 	}
@@ -73,9 +73,9 @@ type HTTPCollector struct {
 	endpoint      *url.URL
 	interval      time.Duration
 	namespace     string
-	metricType    v2.MetricSourceType
+	metricType    autoscalingv2.MetricSourceType
 	metricsGetter *httpmetrics.JSONPathMetricsGetter
-	metric        v2.MetricIdentifier
+	metric        autoscalingv2.MetricIdentifier
 }
 
 func (c *HTTPCollector) GetMetrics() ([]CollectedMetric, error) {

--- a/pkg/collector/http_collector.go
+++ b/pkg/collector/http_collector.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/zalando-incubator/kube-metrics-adapter/pkg/collector/httpmetrics"
 
-	"k8s.io/api/autoscaling/v2beta2"
+	v2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/metrics/pkg/apis/external_metrics"
@@ -26,7 +26,7 @@ func NewHTTPCollectorPlugin() (*HTTPCollectorPlugin, error) {
 	return &HTTPCollectorPlugin{}, nil
 }
 
-func (p *HTTPCollectorPlugin) NewCollector(hpa *v2beta2.HorizontalPodAutoscaler, config *MetricConfig, interval time.Duration) (Collector, error) {
+func (p *HTTPCollectorPlugin) NewCollector(hpa *v2.HorizontalPodAutoscaler, config *MetricConfig, interval time.Duration) (Collector, error) {
 	collector := &HTTPCollector{
 		namespace: hpa.Namespace,
 	}
@@ -73,9 +73,9 @@ type HTTPCollector struct {
 	endpoint      *url.URL
 	interval      time.Duration
 	namespace     string
-	metricType    v2beta2.MetricSourceType
+	metricType    v2.MetricSourceType
 	metricsGetter *httpmetrics.JSONPathMetricsGetter
-	metric        v2beta2.MetricIdentifier
+	metric        v2.MetricIdentifier
 }
 
 func (c *HTTPCollector) GetMetrics() ([]CollectedMetric, error) {

--- a/pkg/collector/http_collector_test.go
+++ b/pkg/collector/http_collector_test.go
@@ -7,8 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"k8s.io/api/autoscaling/v2beta2"
-	autoscalingv2 "k8s.io/api/autoscaling/v2beta2"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -81,8 +80,8 @@ func TestHTTPCollector(t *testing.T) {
 func makeTestHTTPCollectorConfig(endpoint, aggregator string) *MetricConfig {
 	config := &MetricConfig{
 		MetricTypeName: MetricTypeName{
-			Type: v2beta2.ExternalMetricSourceType,
-			Metric: v2beta2.MetricIdentifier{
+			Type: autoscalingv2.ExternalMetricSourceType,
+			Metric: autoscalingv2.MetricIdentifier{
 				Name: "test-metric",
 				Selector: &v1.LabelSelector{
 					MatchLabels: map[string]string{"type": HTTPJSONPathType},

--- a/pkg/collector/influxdb_collector.go
+++ b/pkg/collector/influxdb_collector.go
@@ -6,8 +6,7 @@ import (
 	"time"
 
 	"github.com/influxdata/influxdb-client-go"
-	"k8s.io/api/autoscaling/v2beta2"
-	autoscalingv2 "k8s.io/api/autoscaling/v2beta2"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -39,7 +38,7 @@ func NewInfluxDBCollectorPlugin(client kubernetes.Interface, address, token, org
 	}, nil
 }
 
-func (p *InfluxDBCollectorPlugin) NewCollector(hpa *v2beta2.HorizontalPodAutoscaler, config *MetricConfig, interval time.Duration) (Collector, error) {
+func (p *InfluxDBCollectorPlugin) NewCollector(hpa *autoscalingv2.HorizontalPodAutoscaler, config *MetricConfig, interval time.Duration) (Collector, error) {
 	return NewInfluxDBCollector(hpa, p.address, p.token, p.org, config, interval)
 }
 
@@ -56,7 +55,7 @@ type InfluxDBCollector struct {
 	namespace      string
 }
 
-func NewInfluxDBCollector(hpa *v2beta2.HorizontalPodAutoscaler, address string, token string, org string, config *MetricConfig, interval time.Duration) (*InfluxDBCollector, error) {
+func NewInfluxDBCollector(hpa *autoscalingv2.HorizontalPodAutoscaler, address string, token string, org string, config *MetricConfig, interval time.Duration) (*InfluxDBCollector, error) {
 	collector := &InfluxDBCollector{
 		interval:   interval,
 		metric:     config.Metric,

--- a/pkg/collector/influxdb_collector_test.go
+++ b/pkg/collector/influxdb_collector_test.go
@@ -5,8 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/api/autoscaling/v2beta2"
-	autoscalingv2 "k8s.io/api/autoscaling/v2beta2"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -20,8 +19,8 @@ func TestInfluxDBCollector_New(t *testing.T) {
 	t.Run("simple", func(t *testing.T) {
 		m := &MetricConfig{
 			MetricTypeName: MetricTypeName{
-				Type: v2beta2.ExternalMetricSourceType,
-				Metric: v2beta2.MetricIdentifier{
+				Type: autoscalingv2.ExternalMetricSourceType,
+				Metric: autoscalingv2.MetricIdentifier{
 					Name: "flux-query",
 					// This is actually useless, because the selector should be flattened in Config when parsing.
 					Selector: &v1.LabelSelector{
@@ -59,8 +58,8 @@ func TestInfluxDBCollector_New(t *testing.T) {
 	t.Run("override params", func(t *testing.T) {
 		m := &MetricConfig{
 			MetricTypeName: MetricTypeName{
-				Type: v2beta2.ExternalMetricSourceType,
-				Metric: v2beta2.MetricIdentifier{
+				Type: autoscalingv2.ExternalMetricSourceType,
+				Metric: autoscalingv2.MetricIdentifier{
 					Name: "flux-query",
 					Selector: &v1.LabelSelector{
 						MatchLabels: map[string]string{
@@ -107,15 +106,15 @@ func TestInfluxDBCollector_New(t *testing.T) {
 		{
 			name: "object metric",
 			mTypeName: MetricTypeName{
-				Type: v2beta2.ObjectMetricSourceType,
+				Type: autoscalingv2.ObjectMetricSourceType,
 			},
 			errorStartsWith: "InfluxDB does not support object",
 		},
 		{
 			name: "no selector",
 			mTypeName: MetricTypeName{
-				Type: v2beta2.ExternalMetricSourceType,
-				Metric: v2beta2.MetricIdentifier{
+				Type: autoscalingv2.ExternalMetricSourceType,
+				Metric: autoscalingv2.MetricIdentifier{
 					Name: "flux-query",
 				},
 			},
@@ -130,8 +129,8 @@ func TestInfluxDBCollector_New(t *testing.T) {
 		{
 			name: "referencing non-existing query",
 			mTypeName: MetricTypeName{
-				Type: v2beta2.ExternalMetricSourceType,
-				Metric: v2beta2.MetricIdentifier{
+				Type: autoscalingv2.ExternalMetricSourceType,
+				Metric: autoscalingv2.MetricIdentifier{
 					Name: "flux-query",
 				},
 			},

--- a/pkg/collector/pod_collector.go
+++ b/pkg/collector/pod_collector.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	log "github.com/sirupsen/logrus"
-	autoscalingv2 "k8s.io/api/autoscaling/v2beta2"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/collector/pod_collector_test.go
+++ b/pkg/collector/pod_collector_test.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
-	autoscalingv2 "k8s.io/api/autoscaling/v2beta2"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -280,7 +280,7 @@ func makeTestHPA(t *testing.T, client kubernetes.Interface) *autoscalingv2.Horiz
 			},
 		},
 	}
-	_, err := client.AutoscalingV2beta2().HorizontalPodAutoscalers("test-namespace").Create(context.TODO(), hpa, v1.CreateOptions{})
+	_, err := client.AutoscalingV2().HorizontalPodAutoscalers("test-namespace").Create(context.TODO(), hpa, v1.CreateOptions{})
 	require.NoError(t, err)
 	return hpa
 }

--- a/pkg/collector/prometheus_collector.go
+++ b/pkg/collector/prometheus_collector.go
@@ -10,7 +10,7 @@ import (
 	"github.com/prometheus/client_golang/api"
 	promv1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
-	autoscalingv2 "k8s.io/api/autoscaling/v2beta2"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"

--- a/pkg/collector/prometheus_collector_test.go
+++ b/pkg/collector/prometheus_collector_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	autoscalingv2 "k8s.io/api/autoscaling/v2beta2"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/pkg/collector/scaling_schedule_collector.go
+++ b/pkg/collector/scaling_schedule_collector.go
@@ -8,7 +8,7 @@ import (
 
 	v1 "github.com/zalando-incubator/kube-metrics-adapter/pkg/apis/zalando.org/v1"
 	scheduledscaling "github.com/zalando-incubator/kube-metrics-adapter/pkg/controller/scheduledscaling"
-	autoscalingv2 "k8s.io/api/autoscaling/v2beta2"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/metrics/pkg/apis/custom_metrics"

--- a/pkg/collector/scaling_schedule_collector_test.go
+++ b/pkg/collector/scaling_schedule_collector_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 	v1 "github.com/zalando-incubator/kube-metrics-adapter/pkg/apis/zalando.org/v1"
 	scheduledscaling "github.com/zalando-incubator/kube-metrics-adapter/pkg/controller/scheduledscaling"
-	autoscalingv2 "k8s.io/api/autoscaling/v2beta2"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/pkg/collector/skipper_collector.go
+++ b/pkg/collector/skipper_collector.go
@@ -12,7 +12,7 @@ import (
 
 	rgv1 "github.com/szuecs/routegroup-client/apis/zalando.org/v1"
 	rginterface "github.com/szuecs/routegroup-client/client/clientset/versioned"
-	autoscalingv2 "k8s.io/api/autoscaling/v2beta2"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"

--- a/pkg/collector/skipper_collector_test.go
+++ b/pkg/collector/skipper_collector_test.go
@@ -12,7 +12,7 @@ import (
 	rginterface "github.com/szuecs/routegroup-client/client/clientset/versioned"
 	rgfake "github.com/szuecs/routegroup-client/client/clientset/versioned/fake"
 	appsv1 "k8s.io/api/apps/v1"
-	autoscalingv2 "k8s.io/api/autoscaling/v2beta2"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -35,7 +35,7 @@ func TestTargetRefReplicasDeployments(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create an HPA with the deployment as ref
-	hpa, err := client.AutoscalingV2beta2().HorizontalPodAutoscalers(deployment.Namespace).
+	hpa, err := client.AutoscalingV2().HorizontalPodAutoscalers(deployment.Namespace).
 		Create(context.TODO(), newHPA(defaultNamespace, name, "Deployment"), metav1.CreateOptions{})
 	require.NoError(t, err)
 
@@ -52,7 +52,7 @@ func TestTargetRefReplicasStatefulSets(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create an HPA with the statefulSet as ref
-	hpa, err := client.AutoscalingV2beta2().HorizontalPodAutoscalers(statefulSet.Namespace).
+	hpa, err := client.AutoscalingV2().HorizontalPodAutoscalers(statefulSet.Namespace).
 		Create(context.TODO(), newHPA(defaultNamespace, name, "StatefulSet"), metav1.CreateOptions{})
 	require.NoError(t, err)
 

--- a/pkg/collector/zmon_collector.go
+++ b/pkg/collector/zmon_collector.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/zalando-incubator/kube-metrics-adapter/pkg/zmon"
-	autoscalingv2 "k8s.io/api/autoscaling/v2beta2"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/metrics/pkg/apis/external_metrics"

--- a/pkg/collector/zmon_collector_test.go
+++ b/pkg/collector/zmon_collector_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/zalando-incubator/kube-metrics-adapter/pkg/zmon"
-	autoscalingv2 "k8s.io/api/autoscaling/v2beta2"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/metrics/pkg/apis/external_metrics"

--- a/pkg/provider/hpa.go
+++ b/pkg/provider/hpa.go
@@ -10,7 +10,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	log "github.com/sirupsen/logrus"
-	autoscalingv2 "k8s.io/api/autoscaling/v2beta2"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -122,7 +122,7 @@ func (p *HPAProvider) Run(ctx context.Context) {
 func (p *HPAProvider) updateHPAs() error {
 	p.logger.Info("Looking for HPAs")
 
-	hpas, err := p.client.AutoscalingV2beta2().HorizontalPodAutoscalers(metav1.NamespaceAll).List(context.TODO(), metav1.ListOptions{})
+	hpas, err := p.client.AutoscalingV2().HorizontalPodAutoscalers(metav1.NamespaceAll).List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		return err
 	}

--- a/pkg/provider/hpa_test.go
+++ b/pkg/provider/hpa_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/zalando-incubator/kube-metrics-adapter/pkg/collector"
-	autoscaling "k8s.io/api/autoscaling/v2beta2"
+	autoscaling "k8s.io/api/autoscaling/v2"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -99,7 +99,7 @@ func TestUpdateHPAs(t *testing.T) {
 	fakeClient := fake.NewSimpleClientset()
 
 	var err error
-	hpa, err = fakeClient.AutoscalingV2beta2().HorizontalPodAutoscalers("default").Create(context.TODO(), hpa, metav1.CreateOptions{})
+	hpa, err = fakeClient.AutoscalingV2().HorizontalPodAutoscalers("default").Create(context.TODO(), hpa, metav1.CreateOptions{})
 	require.NoError(t, err)
 
 	collectorFactory := collector.NewCollectorFactory()
@@ -115,7 +115,7 @@ func TestUpdateHPAs(t *testing.T) {
 
 	// update HPA
 	hpa.Annotations["metric-config.pods.requests-per-second.json-path/port"] = "8080"
-	_, err = fakeClient.AutoscalingV2beta2().HorizontalPodAutoscalers("default").Update(context.TODO(), hpa, metav1.UpdateOptions{})
+	_, err = fakeClient.AutoscalingV2().HorizontalPodAutoscalers("default").Update(context.TODO(), hpa, metav1.UpdateOptions{})
 	require.NoError(t, err)
 
 	err = provider.updateHPAs()
@@ -163,7 +163,7 @@ func TestUpdateHPAsDisregardingIncompatibleHPA(t *testing.T) {
 	fakeClient := fake.NewSimpleClientset()
 
 	var err error
-	_, err = fakeClient.AutoscalingV2beta2().HorizontalPodAutoscalers("default").Create(context.TODO(), hpa, metav1.CreateOptions{})
+	_, err = fakeClient.AutoscalingV2().HorizontalPodAutoscalers("default").Create(context.TODO(), hpa, metav1.CreateOptions{})
 	require.NoError(t, err)
 
 	collectorFactory := collector.NewCollectorFactory()

--- a/pkg/provider/metric_store.go
+++ b/pkg/provider/metric_store.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/zalando-incubator/kube-metrics-adapter/pkg/collector"
-	autoscalingv2 "k8s.io/api/autoscaling/v2beta2"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"

--- a/pkg/provider/metric_store_test.go
+++ b/pkg/provider/metric_store_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/zalando-incubator/kube-metrics-adapter/pkg/collector"
 	"golang.org/x/net/context"
-	autoscalingv2 "k8s.io/api/autoscaling/v2beta2"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"


### PR DESCRIPTION
# One-line summary

Switch from `autoscaling/v2beta2` to `autoscaling/v2` for HPA

Issue : #550

## Description

`autoscaling/v2beta2` apiVersion is removed from Kubernetes v1.26. We need to switch from `autoscaling/v2beta2` to `autoscaling/v2` in order to be able to run it. Application's log:

```
W0426 10:15:41.107525       1 warnings.go:70] autoscaling/v2beta2 HorizontalPodAutoscaler is deprecated in v1.23+, unavailable in v1.26+; use autoscaling/v2 HorizontalPodAutoscaler
```

Both apiVersions are available in the currently used lib v1.23, so no dependencies updates are required.

This will bump the minimal supported version of Kubernetes to v1.23.

## Types of Changes
_What types of changes does your code introduce? Keep the ones that apply:_

- New feature (non-breaking change which adds functionality)

## Tasks
_List of tasks you will do to complete the PR_
  - [x] Build the new version
  - [x] Test it in the real k8s cluster
  - [x] Check if any documentation requires an update

## Review
_List of tasks the reviewer must do to review the PR_
- [ ] Tests
- [ ] Documentation
- [ ] CHANGELOG

## Deployment Notes
None