### PR TITLE
all: fix typos discovered by codespell

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ contribution is in line with our goals.
 - Make sure you sign-off on your commits `git commit -s -m "adding X to change Y"`
 - Write good commit messages (see below).
 - Push your changes to a topic branch in your fork of the repository.
-- As you push your changes, update the pull request with new infomation and tasks as you complete them
+- As you push your changes, update the pull request with new information and tasks as you complete them
 - Project maintainers might comment on your work as you progress
 - When you are done, remove the `work in progess` label and ping the maintainers for a review
 - Your pull request must receive a :thumbsup: from two [maintainers](MAINTAINERS)

--- a/README.md
+++ b/README.md
@@ -449,7 +449,7 @@ spec:
 ```
 ### Multiple hostnames per metric
 
-This metric supports a relation of n:1 between hostnames and metrics. The way it works is the measured RPS is the sum of the RPS rate of each of the specified hostnames. This value is further modified by the weight parameter explained bellow.
+This metric supports a relation of n:1 between hostnames and metrics. The way it works is the measured RPS is the sum of the RPS rate of each of the specified hostnames. This value is further modified by the weight parameter explained below.
 
 ### Metric weighting based on backend
 

--- a/docs/cluster_scaling_schedules_crd.yaml
+++ b/docs/cluster_scaling_schedules_crd.yaml
@@ -56,7 +56,7 @@ spec:
                   properties:
                     date:
                       description: Defines the starting date of a OneTime schedule.
-                        It has to be a RFC3339 formated date.
+                        It has to be a RFC3339 formatted date.
                       format: date-time
                       type: string
                     durationMinutes:
@@ -65,7 +65,7 @@ spec:
                       type: integer
                     endDate:
                       description: Defines the ending date of a OneTime schedule.
-                        It must be a RFC3339 formated date.
+                        It must be a RFC3339 formatted date.
                       format: date-time
                       type: string
                     period:

--- a/docs/helm/templates/cluster_scaling_schedules_crd.yaml
+++ b/docs/helm/templates/cluster_scaling_schedules_crd.yaml
@@ -56,7 +56,7 @@ spec:
                   properties:
                     date:
                       description: Defines the starting date of a OneTime schedule.
-                        It has to be a RFC3339 formated date.
+                        It has to be a RFC3339 formatted date.
                       format: date-time
                       type: string
                     durationMinutes:
@@ -65,7 +65,7 @@ spec:
                       type: integer
                     endDate:
                       description: Defines the ending date of a OneTime schedule.
-                        It must be a RFC3339 formated date.
+                        It must be a RFC3339 formatted date.
                       format: date-time
                       type: string
                     period:

--- a/docs/helm/templates/scaling_schedules_crd.yaml
+++ b/docs/helm/templates/scaling_schedules_crd.yaml
@@ -58,7 +58,7 @@ spec:
                   properties:
                     date:
                       description: Defines the starting date of a OneTime schedule.
-                        It has to be a RFC3339 formated date.
+                        It has to be a RFC3339 formatted date.
                       format: date-time
                       type: string
                     durationMinutes:
@@ -67,7 +67,7 @@ spec:
                       type: integer
                     endDate:
                       description: Defines the ending date of a OneTime schedule.
-                        It must be a RFC3339 formated date.
+                        It must be a RFC3339 formatted date.
                       format: date-time
                       type: string
                     period:

--- a/docs/scaling_schedules_crd.yaml
+++ b/docs/scaling_schedules_crd.yaml
@@ -58,7 +58,7 @@ spec:
                   properties:
                     date:
                       description: Defines the starting date of a OneTime schedule.
-                        It has to be a RFC3339 formated date.
+                        It has to be a RFC3339 formatted date.
                       format: date-time
                       type: string
                     durationMinutes:
@@ -67,7 +67,7 @@ spec:
                       type: integer
                     endDate:
                       description: Defines the ending date of a OneTime schedule.
-                        It must be a RFC3339 formated date.
+                        It must be a RFC3339 formatted date.
                       format: date-time
                       type: string
                     period:

--- a/pkg/apis/zalando.org/v1/types.go
+++ b/pkg/apis/zalando.org/v1/types.go
@@ -68,11 +68,11 @@ type Schedule struct {
 	// +optional
 	Period *SchedulePeriod `json:"period,omitempty"`
 	// Defines the starting date of a OneTime schedule. It has to
-	// be a RFC3339 formated date.
+	// be a RFC3339 formatted date.
 	// +optional
 	Date *ScheduleDate `json:"date,omitempty"`
 	// Defines the ending date of a OneTime schedule. It must be
-	// a RFC3339 formated date.
+	// a RFC3339 formatted date.
 	// +optional
 	EndDate *ScheduleDate `json:"endDate,omitempty"`
 	// The duration in minutes (default 0) that the configured value will be

--- a/pkg/collector/skipper_collector_test.go
+++ b/pkg/collector/skipper_collector_test.go
@@ -61,10 +61,10 @@ func TestTargetRefReplicasStatefulSets(t *testing.T) {
 	require.Equal(t, statefulSet.Status.Replicas, replicas)
 }
 
-func newHPA(namesapce string, refName string, refKind string) *autoscalingv2.HorizontalPodAutoscaler {
+func newHPA(namespace string, refName string, refKind string) *autoscalingv2.HorizontalPodAutoscaler {
 	return &autoscalingv2.HorizontalPodAutoscaler{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: namesapce,
+			Name: namespace,
 		},
 		Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
 			ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{

--- a/pkg/provider/hpa.go
+++ b/pkg/provider/hpa.go
@@ -363,7 +363,7 @@ func collectorRunner(ctx context.Context, collector collector.Collector, metrics
 	}
 }
 
-// Remove removes a collector from the Collector schduler. The collector is
+// Remove removes a collector from the Collector scheduler. The collector is
 // stopped before it's removed.
 func (t *CollectorScheduler) Remove(resourceRef resourceReference) {
 	t.Lock()

--- a/pkg/server/start.go
+++ b/pkg/server/start.go
@@ -332,7 +332,7 @@ func (o AdapterServerOptions) RunCustomMetricsAdapterServer(stopCh <-chan struct
 			return fmt.Errorf("failed to register ScalingSchedule object collector plugin: %v", err)
 		}
 
-		// setup ScheduledScaling controller to continously update
+		// setup ScheduledScaling controller to continuously update
 		// status of ScalingSchedule and ClusterScalingSchedule
 		// resources.
 		scheduledScalingController := scheduledscaling.NewController(scalingScheduleClient.ZalandoV1(), scalingSchedulesStore, clusterScalingSchedulesStore, time.Now, o.DefaultScheduledScalingWindow, o.DefaultTimeZone)
@@ -400,7 +400,7 @@ func newOauth2HTTPClient(ctx context.Context, tokenSource oauth2.TokenSource) *h
 	// add HTTP client to context (this is how the oauth2 lib gets it).
 	ctx = context.WithValue(ctx, oauth2.HTTPClient, client)
 
-	// instantiate an http.Client containg the token source.
+	// instantiate an http.Client containing the token source.
 	return oauth2.NewClient(ctx, tokenSource)
 }
 


### PR DESCRIPTION
```
codespell --skip .git | less
```

See https://github.com/codespell-project/codespell
