### PR TITLE
Enable pushing to ghcr.io on merge to master

### DIFF
--- a/.github/workflows/gh-packages.yaml
+++ b/.github/workflows/gh-packages.yaml
@@ -3,6 +3,8 @@ permissions: {}
 
 on:
   push:
+    branches:
+    - master
     tags:
       - '*'
 
@@ -73,6 +75,17 @@ jobs:
           context: .
           build-args: BASE_IMAGE=alpine:3
           platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name != 'pull_request' }}
+          push: ${{ github.event_name != 'pull_request' && startsWith(github.ref, 'refs/tags/v') }}
           tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      # Build and push latest tag
+      - name: Build and push latest
+        uses: docker/build-push-action@2eb1c1961a95fc15694676618e422e8ba1d63825
+        with:
+          context: .
+          build-args: BASE_IMAGE=alpine:3
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
This adds a step to push a `:latest` tag to ghcr.io on every merge to master.
It also changes the push with tag to only trigger when there is a tag created.

Fix #624