### PR TITLE
Fix typo on metric annotation for external RPS metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,7 +426,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: myapp-hpa
   annotations:
-    metric-config.external.example-rps.requests-per-second/hostname: www.example1.com,www.example2.com
+    metric-config.external.example-rps.requests-per-second/hostnames: www.example1.com,www.example2.com
     metric-config.external.example-rps.requests-per-second/weight: "42"
 spec:
   scaleTargetRef:


### PR DESCRIPTION
# One-line summary

Fix typo in the documentation that might mislead users and not properly configure the metric.

## Description
A few sentences describing the overall goals of the pull request's
commits.

## Types of Changes

- Documentation / non-code


## Review

- [ ] Documentation

