### PR TITLE
Fix previous helm chart issue for installation

### DIFF
--- a/docs/helm/Chart.yaml
+++ b/docs/helm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: kube-metrics-adapter
-version: 0.2.0
+version: 0.2.2
 description: kube-metrics-adapter helm chart
 home: https://github.com/zalando-incubator/kube-metrics-adapter
 maintainers:

--- a/docs/helm/templates/cluster_scaling_schedules_crd.yaml
+++ b/docs/helm/templates/cluster_scaling_schedules_crd.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: clusterscalingschedules.zalando.org
 spec:
   group: zalando.org
@@ -23,18 +22,24 @@ spec:
     name: v1
     schema:
       openAPIV3Schema:
-        description: ClusterScalingSchedule describes a cluster scoped time based
-          metric to be used in autoscaling operations.
+        description: |-
+          ClusterScalingSchedule describes a cluster scoped time based metric
+          to be used in autoscaling operations.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -47,25 +52,30 @@ spec:
                 format: int64
                 type: integer
               schedules:
-                description: Schedules is the list of schedules for this ScalingSchedule
+                description: |-
+                  Schedules is the list of schedules for this ScalingSchedule
                   resource. All the schedules defined here will result on the value
-                  to the same metric. New metrics require a new ScalingSchedule resource.
+                  to the same metric. New metrics require a new ScalingSchedule
+                  resource.
                 items:
                   description: Schedule is the schedule details to be used inside
                     a ScalingSchedule.
                   properties:
                     date:
-                      description: Defines the starting date of a OneTime schedule.
-                        It has to be a RFC3339 formatted date.
+                      description: |-
+                        Defines the starting date of a OneTime schedule. It has to
+                        be a RFC3339 formatted date.
                       format: date-time
                       type: string
                     durationMinutes:
-                      description: The duration in minutes (default 0) that the configured
-                        value will be returned for the defined schedule.
+                      description: |-
+                        The duration in minutes (default 0) that the configured value will be
+                        returned for the defined schedule.
                       type: integer
                     endDate:
-                      description: Defines the ending date of a OneTime schedule.
-                        It must be a RFC3339 formatted date.
+                      description: |-
+                        Defines the ending date of a OneTime schedule. It must be
+                        a RFC3339 formatted date.
                       format: date-time
                       type: string
                     period:
@@ -95,8 +105,9 @@ spec:
                           pattern: (([0-1][0-9])|([2][0-3])):([0-5][0-9])
                           type: string
                         timezone:
-                          description: The location name corresponding to a file in
-                            the IANA Time Zone database, like Europe/Berlin.
+                          description: |-
+                            The location name corresponding to a file in the IANA
+                            Time Zone database, like Europe/Berlin.
                           type: string
                       required:
                       - days
@@ -104,7 +115,8 @@ spec:
                       - timezone
                       type: object
                     type:
-                      description: Defines if the schedule is a OneTime schedule or
+                      description: |-
+                        Defines if the schedule is a OneTime schedule or
                         Repeating one. If OneTime, date has to be defined. If Repeating,
                         Period has to be defined.
                       enum:
@@ -129,8 +141,9 @@ spec:
             properties:
               active:
                 default: false
-                description: Active is true if at least one of the schedules defined
-                  in the scaling schedule is currently active.
+                description: |-
+                  Active is true if at least one of the schedules defined in the
+                  scaling schedule is currently active.
                 type: boolean
             type: object
         required:
@@ -140,10 +153,4 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
 {{- end}}

--- a/docs/helm/templates/scaling_schedules_crd.yaml
+++ b/docs/helm/templates/scaling_schedules_crd.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: scalingschedules.zalando.org
 spec:
   group: zalando.org
@@ -25,18 +24,24 @@ spec:
     name: v1
     schema:
       openAPIV3Schema:
-        description: ScalingSchedule describes a namespaced time based metric to be
-          used in autoscaling operations.
+        description: |-
+          ScalingSchedule describes a namespaced time based metric to be used
+          in autoscaling operations.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -49,25 +54,30 @@ spec:
                 format: int64
                 type: integer
               schedules:
-                description: Schedules is the list of schedules for this ScalingSchedule
+                description: |-
+                  Schedules is the list of schedules for this ScalingSchedule
                   resource. All the schedules defined here will result on the value
-                  to the same metric. New metrics require a new ScalingSchedule resource.
+                  to the same metric. New metrics require a new ScalingSchedule
+                  resource.
                 items:
                   description: Schedule is the schedule details to be used inside
                     a ScalingSchedule.
                   properties:
                     date:
-                      description: Defines the starting date of a OneTime schedule.
-                        It has to be a RFC3339 formatted date.
+                      description: |-
+                        Defines the starting date of a OneTime schedule. It has to
+                        be a RFC3339 formatted date.
                       format: date-time
                       type: string
                     durationMinutes:
-                      description: The duration in minutes (default 0) that the configured
-                        value will be returned for the defined schedule.
+                      description: |-
+                        The duration in minutes (default 0) that the configured value will be
+                        returned for the defined schedule.
                       type: integer
                     endDate:
-                      description: Defines the ending date of a OneTime schedule.
-                        It must be a RFC3339 formatted date.
+                      description: |-
+                        Defines the ending date of a OneTime schedule. It must be
+                        a RFC3339 formatted date.
                       format: date-time
                       type: string
                     period:
@@ -97,8 +107,9 @@ spec:
                           pattern: (([0-1][0-9])|([2][0-3])):([0-5][0-9])
                           type: string
                         timezone:
-                          description: The location name corresponding to a file in
-                            the IANA Time Zone database, like Europe/Berlin.
+                          description: |-
+                            The location name corresponding to a file in the IANA
+                            Time Zone database, like Europe/Berlin.
                           type: string
                       required:
                       - days
@@ -106,7 +117,8 @@ spec:
                       - timezone
                       type: object
                     type:
-                      description: Defines if the schedule is a OneTime schedule or
+                      description: |-
+                        Defines if the schedule is a OneTime schedule or
                         Repeating one. If OneTime, date has to be defined. If Repeating,
                         Period has to be defined.
                       enum:
@@ -131,8 +143,9 @@ spec:
             properties:
               active:
                 default: false
-                description: Active is true if at least one of the schedules defined
-                  in the scaling schedule is currently active.
+                description: |-
+                  Active is true if at least one of the schedules defined in the
+                  scaling schedule is currently active.
                 type: boolean
             type: object
         required:
@@ -142,10 +155,4 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
 {{- end}}

--- a/docs/helm/values.yaml
+++ b/docs/helm/values.yaml
@@ -4,7 +4,7 @@ replicas: 1
 
 registry:
   image: registry.opensource.zalan.do/teapot/kube-metrics-adapter
-  imageTag: v0.2.0
+  imageTag: v0.2.2
   imagePullPolicy: IfNotPresent
 
 service:
@@ -14,15 +14,15 @@ service:
 addDirectoryHeader:
 contentionProfiling:
 profiling:
-enableCustomMetricsApi:
-enableExternalMetricsApi:
+enableCustomMetricsApi: true
+enableExternalMetricsApi: true
 credentialsDirectory:
 disregardIncompatibleHPAs:
 http2MaxStreamsPerConnection:
 listerKubeConfig:
 skipperBackendsAnnotation:
 skipperIngressMetrics:
-skipperRouteGroupMetrics:
+skipperRouteGroupMetrics: true
 token:
 vmodule:
 
@@ -95,7 +95,7 @@ resources:
     memory: 100Mi
 
 scalingSchedule:
-  enabled: false
+  enabled: true
 
 nodeSelector:
   kubernetes.io/os: linux


### PR DESCRIPTION
# One-line summary
Current chart is old and not work, I change the code based on the latest version, latest installation files under /docs.
I test and it works well.

Pls review, thanks.

> Issue : #727  


## Description
A few sentences describing the overall goals of the pull request's
commits.

Note:
Current helm charts does not work ./docs/helm
You can install it successfully, but never work.
If you run `cd docs; kubectl apply -f .`, it can work.

If you view current helm charts,
- The version is old.
- The values are not expected.
- Even some status inside template .
It may not professional enough for such a good product.

BTW, feel free to modify if necessary.

## Types of Changes
_What types of changes does your code introduce? Keep the ones that apply:_

- New feature (non-breaking change which adds functionality)
- Bug fix (non-breaking change which fixes an issue)
- Configuration change
- Refactor/improvements
- Documentation / non-code

## Tasks
_List of tasks you will do to complete the PR_
  - [ ] Created Task 1
  - [ ] Created Task 2
  - [ ] To-do Task 3

## Review
_List of tasks the reviewer must do to review the PR_
- [ ] Tests
- [ ] Documentation
- [ ] CHANGELOG

## Deployment Notes
These should highlight any db migrations, feature toggles, etc.
