### PR TITLE
Group go.mod updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,10 +2,18 @@ version: 2
 updates:
 - package-ecosystem: gomod
   directory: "/"
-  schedule:
-    interval: monthly
-    time: "07:00"
+  # schedule:
+  #   interval: monthly
+  #   time: "07:00"
   open-pull-requests-limit: 10
+  groups:
+    all-go-mod-patch-and-minor:
+      patterns: ["*"]
+      update-types: ["patch", "minor"]
+  ignore:
+  # Ignore k8s and its transitives modules as they are upgraded manually
+  - dependency-name: "k8s.io/*"
+    update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
 - package-ecosystem: docker
   directory: "/"
   schedule:


### PR DESCRIPTION
Try out grouping dependabot updates

Disabled the schedule for now to test how it work. Ignoring `k8s.io/` packages as we normally update those manually together with kubernetes-on-aws.

ref: https://github.com/dependabot/dependabot-core/issues/7547