### PR TITLE
Group dependabot updates daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,9 +2,10 @@ version: 2
 updates:
 - package-ecosystem: gomod
   directory: "/"
-  # schedule:
+  schedule:
   #   interval: monthly
-  #   time: "07:00"
+    interval: daily
+    time: "07:00"
   open-pull-requests-limit: 10
   groups:
     all-go-mod-patch-and-minor:


### PR DESCRIPTION
Follow up to #729 the config was invalid without a schedule defined.

![image](https://github.com/zalando-incubator/kube-metrics-adapter/assets/128566/bc26af1b-83fc-45fb-a2d8-d3c43c2f4c3a)
