### PR TITLE
Fix missing AverageValue on HPA

### DIFF
--- a/pkg/controller/scheduledscaling/scheduled_scaling.go
+++ b/pkg/controller/scheduledscaling/scheduled_scaling.go
@@ -320,6 +320,10 @@ func highestActiveSchedule(hpa *autoscalingv2.HorizontalPodAutoscaler, activeSch
 
 		scheduleName := metric.Object.DescribedObject.Name
 
+		if metric.Object.Target.AverageValue == nil {
+			continue
+		}
+
 		target := int64(metric.Object.Target.AverageValue.MilliValue() / 1000)
 		if target == 0 {
 			continue


### PR DESCRIPTION
This is a follow up to #765 

it fixes a bug where the controller would crash if the `AverageValue` was not defined on the user HPA. This is an invalid configuration from the users and should just be ignored.

It adds a test case which fails before the fix.


Example of crash:

```
time="2024-12-13T14:07:00Z" level=info msg="Adjusting scaling"
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x885dae]

goroutine 1918 [running]:
k8s.io/apimachinery/pkg/api/resource.(*Quantity).ScaledValue(0x20?, 0x90?)
	/go/pkg/mod/k8s.io/apimachinery@v0.31.3/pkg/api/resource/quantity.go:797 +0xe
k8s.io/apimachinery/pkg/api/resource.(*Quantity).MilliValue(0xc000605f40?)
	/go/pkg/mod/k8s.io/apimachinery@v0.31.3/pkg/api/resource/quantity.go:789 +0x18
github.com/zalando-incubator/kube-metrics-adapter/pkg/controller/scheduledscaling.highestActiveSchedule(0xc000dc9dc0, 0xc0017b4690)
	/workspace/pkg/controller/scheduledscaling/scheduled_scaling.go:323 +0x1e5
github.com/zalando-incubator/kube-metrics-adapter/pkg/controller/scheduledscaling.(*Controller).adjustHPAScaling(0xc0007298c0, {0x349e700, 0xc000508c80}, 0xc000dc9dc0, 0xc0012e7500?)
	/workspace/pkg/controller/scheduledscaling/scheduled_scaling.go:269 +0x6d
github.com/zalando-incubator/kube-metrics-adapter/pkg/controller/scheduledscaling.(*Controller).adjustScaling.func1()
	/workspace/pkg/controller/scheduledscaling/scheduled_scaling.go:361 +0x27
golang.org/x/sync/errgroup.(*Group).Go.func1()
	/go/pkg/mod/golang.org/x/sync@v0.10.0/errgroup/errgroup.go:78 +0x50
created by golang.org/x/sync/errgroup.(*Group).Go in goroutine 130
	/go/pkg/mod/golang.org/x/sync@v0.10.0/errgroup/errgroup.go:75 +0x96
```