### PR TITLE
Add support for ajson scripting engine 

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ returns something that can be turned into a `float64`.
 
 The `json-eval` configuration option allows for more complex calculations to be
 performed on the extracted metric. The `json-eval` expression is evaluated using
-ajson's script engine.
+[ajson's script engine](https://github.com/spyzhov/ajson?tab=readme-ov-file#script-engine).
 
 The other configuration options `path`, `port` and `scheme` specify where the metrics
 endpoint is exposed on the pod. The `path` and `port` options do not have default values

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ metadata:
   annotations:
     # metric-config.<metricType>.<metricName>.<collectorType>/<configKey>
     metric-config.pods.requests-per-second.json-path/json-key: "$.http_server.rps"
+    metric-config.pods.requests-per-second.json-path/json-eval: "ceil($['active processes'] / $['total processes'] * 100)" # cannot use both json-eval and json-key
     metric-config.pods.requests-per-second.json-path/path: /metrics
     metric-config.pods.requests-per-second.json-path/port: "9090"
     metric-config.pods.requests-per-second.json-path/scheme: "https"
@@ -157,6 +158,10 @@ The json-path query support depends on the
 [github.com/spyzhov/ajson](https://github.com/spyzhov/ajson) library.
 See the README for possible queries. It's expected that the metric you query
 returns something that can be turned into a `float64`.
+
+The `json-eval` configuration option allows for more complex calculations to be
+performed on the extracted metric. The `json-eval` expression is evaluated using
+ajson's script engine.
 
 The other configuration options `path`, `port` and `scheme` specify where the metrics
 endpoint is exposed on the pod. The `path` and `port` options do not have default values
@@ -825,6 +830,7 @@ metadata:
   annotations:
     # metric-config.<metricType>.<metricName>.<collectorType>/<configKey>
     metric-config.external.unique-metric-name.json-path/json-key: "$.some-metric.value"
+    metric-config.external.unique-metric-name.json-path/json-eval: ceil($['active processes'] / $['total processes'] * 100) # cannot use both json-eval and json-key
     metric-config.external.unique-metric-name.json-path/endpoint: "http://metric-source.app-namespace:8080/metrics"
     metric-config.external.unique-metric-name.json-path/aggregator: "max"
     metric-config.external.unique-metric-name.json-path/interval: "60s" # optional
@@ -852,6 +858,8 @@ The HTTP collector similar to the Pod Metrics collector. The following
 configuration values are supported:
 
 - `json-key` to specify the JSON path of the metric to be queried
+- `json-eval` to specify an evaluate string to [evaluate on the script engine](https://github.com/spyzhov/ajson?tab=readme-ov-file#script-engine), 
+    cannot be used in conjunction with `json-key`
 - `endpoint` the fully formed path to query for the metric. In the above example a Kubernetes _Service_
     in the namespace `app-namespace` is called.
 - `aggregator` is only required if the metric is an array of values and specifies how the values

--- a/pkg/collector/http_collector.go
+++ b/pkg/collector/http_collector.go
@@ -62,7 +62,7 @@ func (p *HTTPCollectorPlugin) NewCollector(_ context.Context, hpa *autoscalingv2
 			return nil, err
 		}
 	}
-	jsonPathGetter, err := httpmetrics.NewJSONPathMetricsGetter(httpmetrics.DefaultMetricsHTTPClient(), aggFunc, jsonPath)
+	jsonPathGetter, err := httpmetrics.NewJSONPathMetricsGetter(httpmetrics.DefaultMetricsHTTPClient(), aggFunc, jsonPath, "")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/collector/httpmetrics/pod_metrics.go
+++ b/pkg/collector/httpmetrics/pod_metrics.go
@@ -33,12 +33,23 @@ func NewPodMetricsJSONPathGetter(config map[string]string) (*PodMetricsJSONPathG
 	getter := PodMetricsJSONPathGetter{}
 	var (
 		jsonPath   string
+		jsonEval   string
 		aggregator AggregatorFunc
 		err        error
 	)
 
 	if v, ok := config["json-key"]; ok {
 		jsonPath = v
+	}
+
+	if v, ok := config["json-eval"]; ok {
+		jsonEval = v
+	}
+
+	if jsonPath == "" && jsonEval == "" {
+		return nil, fmt.Errorf("config value json-key or json-eval must be set")
+	} else if jsonPath != "" && jsonEval != "" {
+		return nil, fmt.Errorf("config value json-key and json-eval are mutually exclusive")
 	}
 
 	if v, ok := config["scheme"]; ok {
@@ -93,7 +104,7 @@ func NewPodMetricsJSONPathGetter(config map[string]string) (*PodMetricsJSONPathG
 		connectTimeout = d
 	}
 
-	jsonPathGetter, err := NewJSONPathMetricsGetter(CustomMetricsHTTPClient(requestTimeout, connectTimeout), aggregator, jsonPath)
+	jsonPathGetter, err := NewJSONPathMetricsGetter(CustomMetricsHTTPClient(requestTimeout, connectTimeout), aggregator, jsonPath, jsonEval)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/collector/httpmetrics/pod_metrics_test.go
+++ b/pkg/collector/httpmetrics/pod_metrics_test.go
@@ -86,6 +86,17 @@ func TestNewPodJSONPathMetricsGetter(t *testing.T) {
 		port:         9090,
 		rawQuery:     "foo=bar&baz=bop",
 	}, getterWithRawQuery)
+
+	configErrorMixedPathEval := map[string]string{
+		"json-key": "{}",
+		"json-eval": "avg($.values)",
+		"scheme":   "http",
+		"path":     "/metrics",
+		"port":     "9090",
+	}
+
+	_, err6 := NewPodMetricsJSONPathGetter(configErrorMixedPathEval)
+	require.Error(t, err6)
 }
 
 func TestBuildMetricsURL(t *testing.T) {


### PR DESCRIPTION
# One-line summary
Implements ajson's scripting engine on Pod collector through a new `json-eval` config key.

> Issue : #781

## Description
This allows to do "basic" data massaging before ingestion using the [scripting engine](https://github.com/spyzhov/ajson?tab=readme-ov-file#script-engine). This allows things like arithmetic operations on different keys of the returned document, to calculate, for example, usage percents given idle and total workers.

## Types of Changes
_What types of changes does your code introduce? Keep the ones that apply:_

- New feature (non-breaking change which adds functionality)
- Configuration change

## Tasks
_List of tasks you will do to complete the PR_
  - [x] json-eval on Pod collector
  - [x] json-eval on HTTP collector
  - [x] Tests on `PodMetrics` and `JSONPath`

## Review
_List of tasks the reviewer must do to review the PR_
- [ ] Tests
- [ ] Documentation
- [ ] CHANGELOG

## Deployment Notes
`json-key` and `json-eval` are mutually exclusive, this PR adds checks for either of them being present and not both at the same time.