### PR TITLE
Remove all category from ClusterScalingSchedule

### DIFF
--- a/docs/cluster_scaling_schedules_crd.yaml
+++ b/docs/cluster_scaling_schedules_crd.yaml
@@ -8,8 +8,6 @@ metadata:
 spec:
   group: zalando.org
   names:
-    categories:
-    - all
     kind: ClusterScalingSchedule
     listKind: ClusterScalingScheduleList
     plural: clusterscalingschedules

--- a/pkg/apis/zalando.org/v1/types.go
+++ b/pkg/apis/zalando.org/v1/types.go
@@ -51,7 +51,7 @@ func (s *ScalingSchedule) ResourceSpec() ScalingScheduleSpec {
 // ClusterScalingSchedule describes a cluster scoped time based metric
 // to be used in autoscaling operations.
 // +k8s:deepcopy-gen=true
-// +kubebuilder:resource:categories=all,scope=Cluster,shortName=css;clustersched;clusterschedule
+// +kubebuilder:resource:scope=Cluster,shortName=css;clustersched;clusterschedule
 // +kubebuilder:printcolumn:name="Active",type=boolean,JSONPath=`.status.active`,description="Whether one or more schedules are currently active."
 // +kubebuilder:subresource:status
 type ClusterScalingSchedule struct {


### PR DESCRIPTION
Same as https://github.com/zalando-incubator/kubernetes-on-aws/pull/9302

> ClusterScalingSchedule is the only global CRD that is displayed as part of kubectl get all. This is fairly confusing when you want to see "all" resources in a namespace (knowing that all is not really everything) but you constantly also see the ClusterScalingSchedule everytime.

> This was recently introduced by a bug fix but turns out the old (bugged) behaviour was actually better.
