### PR TITLE
Add Prometheus bearer token authentication support

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,10 @@ metadata:
     # If specified, then this prometheus server is used,
     # instead of the prometheus server specified as the CLI argument `--prometheus-server`.
     metric-config.external.processed-events-per-second.prometheus/prometheus-server: http://prometheus.my-namespace.svc
+    # This annotation is optional.
+    # If specified, this will use one of the additional prometheus servers configured via the
+    # --additional-prometheus-server <name>=<url>,<name>=<url>,... CLI argument.
+    metric-config.external.processed-events-per-second.prometheus/prometheus-server-alias: external-prometheus
     # metric-config.<metricType>.<metricName>.<collectorType>/<configKey>
     metric-config.external.processed-events-per-second.prometheus/query: |
       scalar(sum(rate(event-service_events_count{application="event-service",processed="true"}[1m])))

--- a/docs/helm/templates/deployment.yaml
+++ b/docs/helm/templates/deployment.yaml
@@ -39,170 +39,179 @@ spec:
           args:
             {{- if .Values.addDirectoryHeader }}
             - --add_dir_header={{ .Values.addDirectoryHeader }}
-            {{- end}}
+            {{- end }}
             {{- if .Values.log.alsoToStderr }}
             - --alsologtostderr={{ .Values.log.alsoToStderr }}
-            {{- end}}
+            {{- end }}
             {{- if .Values.authentication.kubeConfig }}
             - --authentication-kubeconfig={{ .Values.authentication.kubeConfig }}
-            {{- end}}
+            {{- end }}
             {{- if .Values.authentication.skipLookup }}
             - --authentication-skip-lookup={{ .Values.authentication.skipLookup }}
-            {{- end}}
+            {{- end }}
             {{- if .Values.authentication.tokenWebhookCacheTtl }}
             - --authentication-token-webhook-cache-ttl={{ .Values.authentication.tokenWebhookCacheTtl }}
-            {{- end}}
+            {{- end }}
             {{- if .Values.authentication.tolerateLookupFailure }}
             - --authentication-tolerate-lookup-failure={{ .Values.authentication.tolerateLookupFailure }}
-            {{- end}}
+            {{- end }}
             {{- if .Values.authorization.alwaysAllowPaths }}
             - --authorization-always-allow-paths={{ .Values.authorization.alwaysAllowPaths }}
-            {{- end}}
+            {{- end }}
             {{- if .Values.authorization.kubeConfig }}
             - --authorization-kubeconfig={{ .Values.authorization.kubeConfig }}
-            {{- end}}
+            {{- end }}
             {{- if .Values.authorization.webhookCache.authorizedTtl }}
             - --authorization-webhook-cache-authorized-ttl={{ .Values.authorization.webhookCache.authorizedTtl }}
-            {{- end}}
+            {{- end }}
             {{- if .Values.authorization.webhookCache.unauthorizedTtl }}
             - --authorization-webhook-cache-unauthorized-ttl={{ .Values.authorization.webhookCache.unauthorizedTtl }}
-            {{- end}}
+            {{- end }}
             {{- if .Values.aws.externalMetrics }}
             - --aws-external-metrics={{ .Values.aws.externalMetrics }}
-            {{- end}}
+            {{- end }}
             {{- if .Values.aws.region }}
             - --aws-region={{ .Values.aws.region }}
-            {{- end}}
+            {{- end }}
             {{- if .Values.tls.certificateDirectory }}
             - --cert-dir={{ .Values.tls.certificateDirectory }}
-            {{- end}}
+            {{- end }}
             {{- if .Values.tls.clientCaFile }}
             - --client-ca-file={{ .Values.tls.clientCaFile }}
-            {{- end}}
+            {{- end }}
             {{- if .Values.contentionProfiling }}
             - --contention-profiling={{ .Values.contentionProfiling }}
-            {{- end}}
+            {{- end }}
             {{- if .Values.credentialsDirectory }}
             - --credentials-dir={{ .Values.credentialsDirectory }}
-            {{- end}}
+            {{- end }}
             {{- if .Values.disregardIncompatibleHPAs }}
             - --disregard-incompatible-hpas={{ .Values.disregardIncompatibleHPAs }}
-            {{- end}}
+            {{- end }}
             {{- if .Values.enableCustomMetricsApi }}
             - --enable-custom-metrics-api={{ .Values.enableCustomMetricsApi }}
-            {{- end}}
+            {{- end }}
             {{- if .Values.enableExternalMetricsApi }}
             - --enable-external-metrics-api={{ .Values.enableExternalMetricsApi }}
-            {{- end}}
+            {{- end }}
             {{- if .Values.http2MaxStreamsPerConnection }}
             - --http2-max-streams-per-connection={{ .Values.http2MaxStreamsPerConnection }}
-            {{- end}}
+            {{- end }}
             {{- if .Values.influxDB.address }}
             - --influxdb-address={{ .Values.influxDB.address }}
-            {{- end}}
+            {{- end }}
             {{- if .Values.influxDB.organization }}
             - --influxdb-org={{ .Values.influxDB.organization }}
-            {{- end}}
+            {{- end }}
             {{- if .Values.influxDB.token }}
             - --influxdb-token={{ .Values.influxDB.token }}
-            {{- end}}
+            {{- end }}
             {{- if .Values.listerKubeConfig }}
             - --lister-kubeconfig={{ .Values.listerKubeConfig }}
-            {{- end}}
+            {{- end }}
             {{- if .Values.log.flushFrequency }}
             - --log-flush-frequency={{ .Values.log.flushFrequency }}
-            {{- end}}
+            {{- end }}
             {{- if .Values.log.backtraceAtTraceLocation }}
             - --log_backtrace_at={{ .Values.log.backtraceAtTraceLocation }}
-            {{- end}}
+            {{- end }}
             {{- if .Values.log.directory }}
             - --log_dir={{ .Values.log.directory }}
-            {{- end}}
+            {{- end }}
             {{- if .Values.log.file }}
             - --log_file={{ .Values.log.file }}
-            {{- end}}
+            {{- end }}
             {{- if .Values.log.fileMaxSize }}
             - --log_file_max_size={{ .Values.log.fileMaxSize }}
-            {{- end}}
+            {{- end }}
             {{- if .Values.log.toStderr }}
             - --logtostderr={{ .Values.log.toStderr }}
-            {{- end}}
+            {{- end }}
             {{- if .Values.prometheus.metricsAddress }}
             - --metrics-address={{ .Values.prometheus.metricsAddress }}
-            {{- end}}
+            {{- end }}
             {{- if .Values.profiling }}
             - --profiling={{ .Values.profiling }}
-            {{- end}}
+            {{- end }}
             {{- if .Values.prometheus.server }}
             - --prometheus-server={{ .Values.prometheus.server }}
-            {{- end}}
+            {{- end }}
+            {{- if .Values.prometheus.serverTokenFile }}
+            - --prometheus-server-token-file={{ .Values.prometheus.serverTokenFile }}
+            {{- end }}
+            {{- range $name, $url := .Values.prometheus.additionalServers }}
+            - --additional-prometheus-server={{ $name }}={{ $url }}
+            {{- end }}
+            {{- range $name, $path := .Values.prometheus.additionalServerTokenFiles }}
+            - --additional-prometheus-server-token-file={{ $name }}={{ $path }}
+            {{- end }}
             {{- if .Values.requestHeader.allowedNames }}
             - --requestheader-allowed-names={{ .Values.requestHeader.allowedNames }}
-            {{- end}}
+            {{- end }}
             {{- if .Values.requestHeader.clientCaFile }}
             - --requestheader-client-ca-file={{ .Values.requestHeader.clientCaFile }}
-            {{- end}}
+            {{- end }}
             {{- if .Values.requestHeader.extraHeadersPrefix }}
             - --requestheader-extra-headers-prefix={{ .Values.requestHeader.extraHeadersPrefix }}
-            {{- end}}
+            {{- end }}
             {{- if .Values.requestHeader.groupHeaders }}
             - --requestheader-group-headers={{ .Values.requestHeader.groupHeaders }}
-            {{- end}}
+            {{- end }}
             {{- if .Values.requestHeader.usernameHeaders }}
             - --requestheader-username-headers={{ .Values.requestHeader.usernameHeaders }}
-            {{- end}}
+            {{- end }}
             - --secure-port={{ .Values.service.internalPort }}
             {{- if .Values.log.skipHeaders }}
             - --skip_headers={{ .Values.log.skipHeaders }}
-            {{- end}}
+            {{- end }}
             {{- if .Values.log.skipLogHeaders }}
             - --skip_log_headers={{ .Values.log.skipLogHeaders }}
-            {{- end}}
+            {{- end }}
             {{- if .Values.skipperBackendsAnnotation }}
             - --skipper-backends-annotation={{ .Values.skipperBackendsAnnotation }}
-            {{- end}}
+            {{- end }}
             {{- if .Values.skipperIngressMetrics }}
             - --skipper-ingress-metrics={{ .Values.skipperIngressMetrics }}
-            {{- end}}
+            {{- end }}
             {{- if .Values.skipperRouteGroupMetrics }}
             - --skipper-routegroup-metrics={{ .Values.skipperRouteGroupMetrics }}
-            {{- end}}
+            {{- end }}
             {{- if .Values.log.stderrThreshold }}
             - --stderrthreshold={{ .Values.log.stderrThreshold }}
-            {{- end}}
+            {{- end }}
             {{- if .Values.tls.certFile }}
             - --tls-cert-file={{ .Values.tls.certFile }}
-            {{- end}}
+            {{- end }}
             {{- if .Values.tls.cipherSuites }}
             - --tls-cipher-suites={{ .Values.tls.cipherSuites }}
-            {{- end}}
+            {{- end }}
             {{- if .Values.tls.minVersion }}
             - --tls-min-version={{ .Values.tls.minVersion }}
-            {{- end}}
+            {{- end }}
             {{- if .Values.tls.privateKeyFile }}
             - --tls-private-key-file={{ .Values.tls.privateKeyFile }}
-            {{- end}}
+            {{- end }}
             {{- if .Values.tls.sniCertKey }}
             - --tls-sni-cert-key={{ .Values.tls.sniCertKey }}
-            {{- end}}
+            {{- end }}
             {{- if .Values.token }}
             - --token={{ .Values.token }}
-            {{- end}}
+            {{- end }}
             {{- if .Values.log.level }}
             - --v={{ .Values.log.level }}
-            {{- end}}
+            {{- end }}
             {{- if .Values.vmodule }}
             - --vmodule={{ .Values.vmodule }}
-            {{- end}}
+            {{- end }}
             {{- if .Values.zmon.kariosdbEndpoint }}
             - --zmon-kariosdb-endpoint={{ .Values.zmon.kariosdbEndpoint }}
-            {{- end}}
+            {{- end }}
             {{- if .Values.zmon.tokenName }}
             - --zmon-token-name={{ .Values.zmon.tokenName }}
-            {{- end}}
+            {{- end }}
             {{- if .Values.scalingSchedule.enabled }}
             - --scaling-schedule
-            {{- end}}
+            {{- end }}
           resources:
             limits:
               cpu: {{ .Values.resources.limits.cpu }}
@@ -210,3 +219,9 @@ spec:
             requests:
               cpu: {{ .Values.resources.requests.cpu }}
               memory: {{ .Values.resources.requests.memory }}
+          {{- if .Values.volumeMounts }}
+          volumeMounts: {{- toYaml .Values.volumeMounts | nindent 12 }}
+          {{- end }}
+      {{- if .Values.volumes }}
+      volumes: {{- toYaml .Values.volumes | nindent 8 }}
+      {{- end }}

--- a/docs/helm/values.yaml
+++ b/docs/helm/values.yaml
@@ -63,6 +63,9 @@ log:
 
 prometheus:
   server: http://prometheus.kube-system.svc.cluster.local
+  serverTokenFile:
+  additionalServers: {}
+  additionalServerTokenFiles: {}
   metricsAddress:
 
 requestHeader:
@@ -109,3 +112,7 @@ priorityClassName: ""
 podAnnotations: {}
 
 serviceAccountAnnotations: {}
+
+volumes: []
+
+volumeMounts: []

--- a/go.mod
+++ b/go.mod
@@ -105,6 +105,7 @@ require (
 	github.com/influxdata/line-protocol v0.0.0-20210922203350-b1ad95c89adf // indirect
 	github.com/iris-contrib/schema v0.0.6 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
+	github.com/jpillora/backoff v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/kataras/blocks v0.0.8 // indirect
 	github.com/kataras/golog v0.1.12 // indirect
@@ -126,6 +127,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f // indirect
 	github.com/pelletier/go-toml/v2 v2.2.2 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect

--- a/pkg/collector/external_rps_collector_test.go
+++ b/pkg/collector/external_rps_collector_test.go
@@ -279,7 +279,7 @@ func TestExternalRPSPrometheusCollectorInteraction(t *testing.T) {
 	}
 
 	factory := NewCollectorFactory()
-	promPlugin, err := NewPrometheusCollectorPlugin(nil, "http://prometheus")
+	promPlugin, err := NewPrometheusCollectorPlugin(nil, "http://prometheus", "", map[string]string{}, map[string]string{})
 	require.NoError(t, err)
 	factory.RegisterExternalCollector([]string{PrometheusMetricType, PrometheusMetricNameLegacy}, promPlugin)
 	hostnamePlugin, err := NewExternalRPSCollectorPlugin(promPlugin, "a_metric")

--- a/pkg/collector/prometheus_collector_test.go
+++ b/pkg/collector/prometheus_collector_test.go
@@ -173,7 +173,7 @@ func TestNewPrometheusCollector(t *testing.T) {
 	} {
 		t.Run(tc.msg, func(t *testing.T) {
 			collectorFactory := NewCollectorFactory()
-			promPlugin, err := NewPrometheusCollectorPlugin(nil, "http://prometheus")
+			promPlugin, err := NewPrometheusCollectorPlugin(nil, "http://prometheus", "", map[string]string{}, map[string]string{})
 			require.NoError(t, err)
 			collectorFactory.RegisterExternalCollector([]string{PrometheusMetricType, PrometheusMetricNameLegacy}, promPlugin)
 			configs, err := ParseHPAMetrics(tc.hpa)


### PR DESCRIPTION
# One-line summary
        Add Prometheus server aliases and bearer token authentication support


## Description
This pull request adds support for bearer token authentication to the Prometheus metrics provider through a bearer token file. It:


* Adds a `--prometheus-server-token-file` flag to support authenticating to a prometheus server using a bearer token file.
* Adds a `prometheus-server-alias` HPA annotation that overrides the Prometheus server for one defined in `--additional-prometheus-server=<name>=<url>` and `--additional-prometheus-server-token-file=<name>=<url>` repeatable flags.

As an example, this can be used to query metrics from Google Cloud's Managed Service for Prometheus endpoint: 
```
--additional-prometheus-server=google=https://monitoring.googleapis.com/v1/projects/PROJECT_ID/location/global/prometheus/
--additional-prometheus-server-token-file=google=/var/run/secrets/tokens/google
```

This would also address https://github.com/zalando-incubator/kube-metrics-adapter/issues/797

## Types of Changes
_What types of changes does your code introduce? Keep the ones that apply:_

- New feature (non-breaking change which adds functionality)

## Tasks
_List of tasks you will do to complete the PR_
  - [x] Add support for Prometheus bearer token files in the global config
  - [x] Add support for additional Prometheus servers through command-line flags
  - [x] Add support for Prometheus server aliases in HPA annotation
  - [x] Add support for volumes and mounts in the Helm chart
  - [x] Add documentation around the annotation in the README file

## Review
_List of tasks the reviewer must do to review the PR_
- [ ] Tests
- [ ] Documentation
- [ ] CHANGELOG

## Deployment Notes
