### PR TITLE
Use static base image for public images

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-go@v5
       with:
-        go-version: '^1.24'
+        go-version: '^1.25'
     - run: go version
     - run: go install github.com/mattn/goveralls@latest
     - run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest

--- a/.github/workflows/gh-packages.yaml
+++ b/.github/workflows/gh-packages.yaml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753
         with:
           # https://www.npmjs.com/package/semver#caret-ranges-123-025-004
-          go-version: '^1.21'
+          go-version: '^1.25'
 
       - name: Login to Github Container Registry
         uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc
@@ -73,7 +73,7 @@ jobs:
         uses: docker/build-push-action@2eb1c1961a95fc15694676618e422e8ba1d63825
         with:
           context: .
-          build-args: BASE_IMAGE=alpine:3
+          build-args: BASE_IMAGE=gcr.io/distroless/static-debian12
           platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' && startsWith(github.ref, 'refs/tags/v') }}
           tags: ${{ steps.meta.outputs.tags }}
@@ -84,7 +84,7 @@ jobs:
         uses: docker/build-push-action@2eb1c1961a95fc15694676618e422e8ba1d63825
         with:
           context: .
-          build-args: BASE_IMAGE=alpine:3
+          build-args: BASE_IMAGE=gcr.io/distroless/static-debian12
           platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest


### PR DESCRIPTION
* Use distroless static base image for the public images. Reduce chance of vulnerabilities and reduce size.
* Update GH actions to Go 1.25

Fix: #817, #813