### PR TITLE
dependabot: update gh actions monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,3 +19,8 @@ updates:
     interval: monthly
     time: "07:00"
   open-pull-requests-limit: 10
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "monthly"
+  open-pull-requests-limit: 10


### PR DESCRIPTION
Configure dependabot to update gh-action versions monthly.