### PR TITLE
dependabot: group gh action updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,4 +23,7 @@ updates:
   directory: "/"
   schedule:
     interval: "monthly"
-  open-pull-requests-limit: 10
+  groups:
+    github-actions:
+      patterns:
+        - "*"


### PR DESCRIPTION
Follow up to #819 

Group dependabot updates for gh actions such that we don't need to merge 10 individual PRs.