### PR TITLE
scheduled-scaling: Handle mili values (fractions) in target value

### DIFF
--- a/pkg/controller/scheduledscaling/scheduled_scaling.go
+++ b/pkg/controller/scheduledscaling/scheduled_scaling.go
@@ -57,7 +57,7 @@ var (
 type now func() time.Time
 
 type scalingScheduleStore interface {
-	List() []interface{}
+	List() []any
 }
 
 type Controller struct {
@@ -325,7 +325,7 @@ func highestActiveSchedule(hpa *autoscalingv2.HorizontalPodAutoscaler, activeSch
 			continue
 		}
 
-		target := int64(metric.Object.Target.AverageValue.MilliValue() / 1000)
+		target := float64(metric.Object.Target.AverageValue.MilliValue()) / 1000.0
 		if target == 0 {
 			continue
 		}
@@ -338,10 +338,10 @@ func highestActiveSchedule(hpa *autoscalingv2.HorizontalPodAutoscaler, activeSch
 			value = activeSchedules[scheduleName]
 		}
 
-		expected := int64(math.Ceil(float64(value) / float64(target)))
+		expected := int64(math.Ceil(float64(value) / target))
 		if expected > highestExpected {
 			highestExpected = expected
-			usageRatio = float64(value) / (float64(target) * float64(currentReplicas))
+			usageRatio = float64(value) / (target * float64(currentReplicas))
 			highestObject = metric.Object.DescribedObject
 		}
 	}


### PR DESCRIPTION
This fixes a bug where the logic for adjusting scheduled scaling when the change is less than 10% didn't deal with fractions (mili values) correctly.

Example:

Scaling Schedule had the target value of: `7875`
HPA had the current number of replicas: `637`
target on the HPA: `11720m == 11.72`

With this the expected number of replicas would be: `ceil(7875/11.72) = 672`, a change of  `0.0548` which is within the default `0.1` toleration, such that the adjuster should kick in.

However, due to the bug, the target value `11.72` was rounded off to `11` in the calculation such that the expected number of replicas was `ceil(7875/11) = 716` which is a change of `0.1239`, above the default `0.1` toleration, so the adjuster assumed the HPA would scale.

The fix is to correctly convert the target to a float not loosing the decimals.