### PR TITLE
Use stdlib context package

### DIFF
--- a/pkg/collector/fake_collector_test.go
+++ b/pkg/collector/fake_collector_test.go
@@ -1,9 +1,9 @@
 package collector
 
 import (
+	"context"
 	"time"
 
-	"golang.org/x/net/context"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/metrics/pkg/apis/custom_metrics"

--- a/pkg/collector/zmon_collector.go
+++ b/pkg/collector/zmon_collector.go
@@ -1,13 +1,13 @@
 package collector
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/zalando-incubator/kube-metrics-adapter/pkg/zmon"
-	"golang.org/x/net/context"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/controller/scheduledscaling/scaler.go
+++ b/pkg/controller/scheduledscaling/scaler.go
@@ -1,10 +1,10 @@
 package scheduledscaling
 
 import (
+	"context"
 	"fmt"
 	"time"
 
-	"golang.org/x/net/context"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"

--- a/pkg/controller/scheduledscaling/scheduled_scaling.go
+++ b/pkg/controller/scheduledscaling/scheduled_scaling.go
@@ -1,6 +1,7 @@
 package scheduledscaling
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"math"
@@ -10,7 +11,6 @@ import (
 	v1 "github.com/zalando-incubator/kube-metrics-adapter/pkg/apis/zalando.org/v1"
 	zalandov1 "github.com/zalando-incubator/kube-metrics-adapter/pkg/client/clientset/versioned/typed/zalando.org/v1"
 	"github.com/zalando-incubator/kube-metrics-adapter/pkg/recorder"
-	"golang.org/x/net/context"
 	"golang.org/x/sync/errgroup"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"

--- a/pkg/provider/metric_store_test.go
+++ b/pkg/provider/metric_store_test.go
@@ -1,13 +1,13 @@
 package provider
 
 import (
+	"context"
 	"sort"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/zalando-incubator/kube-metrics-adapter/pkg/collector"
-	"golang.org/x/net/context"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"


### PR DESCRIPTION
Use stdlib `context` package instead of `golang.org/x/net/context`

This is correctly failing linting:

```
pkg/collector/zmon_collector.go:10:2: SA1019: "golang.org/x/net/context" is deprecated: Use the standard library context package instead. (staticcheck)
```