### PR TITLE
Implement a --log-level flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -37,6 +37,7 @@ func main() {
 
 	cmd := server.NewCommandStartAdapterServer(wait.NeverStop)
 	cmd.Flags().AddGoFlagSet(flag.CommandLine)
+
 	if err := cmd.Execute(); err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
# One-line summary

Add a `--log-level` flag (default level info) to allow making log output less verbose.

## Description
The default log level setting is very noisy when `kube-metrics-adapter` is deployed on large clusters. This may lead to performance and monitoring issues where important logs are lost due to volume.

## Types of Changes

- New feature (non-breaking change which adds functionality)
- Configuration change

## Review
_List of tasks the reviewer must do to review the PR_
- [ ] Tests
- [ ] Documentation
- [ ] CHANGELOG
