### PR TITLE
Enrich GetMetrics errors with metric identifier

### DIFF
--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -3,6 +3,7 @@ package collector
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -180,6 +181,25 @@ func (c *CollectorFactory) NewCollector(ctx context.Context, hpa *autoscalingv2.
 type MetricTypeName struct {
 	Type   autoscalingv2.MetricSourceType
 	Metric autoscalingv2.MetricIdentifier
+}
+
+func (m MetricTypeName) String() string {
+	str := fmt.Sprintf("%s/%s", m.Type, m.Metric.Name)
+	if len(m.Metric.Selector.MatchLabels) > 0 {
+		str += " " + mapToString(m.Metric.Selector.MatchLabels)
+	}
+	return str
+}
+
+func mapToString(m map[string]string) string {
+	str := "{"
+	keyVals := make([]string, 0, len(m))
+	for k, v := range m {
+		keyVals = append(keyVals, fmt.Sprintf("%s=%s", k, v))
+	}
+	str += strings.Join(keyVals, ",")
+	str += "}"
+	return str
 }
 
 type CollectedMetric struct {

--- a/pkg/provider/hpa.go
+++ b/pkg/provider/hpa.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"errors"
+	"fmt"
 	"reflect"
 	"sync"
 	"time"
@@ -375,18 +376,18 @@ func (t *CollectorScheduler) Add(resourceRef resourceReference, typeName collect
 	collectors[typeName] = cancel
 
 	// start runner for new collector
-	go collectorRunner(ctx, metricCollector, t.metricSink)
+	go collectorRunner(ctx, typeName, metricCollector, t.metricSink)
 }
 
 // collectorRunner runs a collector at the desirec interval. If the passed
 // context is canceled the collection will be stopped.
-func collectorRunner(ctx context.Context, collector collector.Collector, metricsc chan<- metricCollection) {
+func collectorRunner(ctx context.Context, typeName collector.MetricTypeName, collector collector.Collector, metricsc chan<- metricCollection) {
 	for {
 		values, err := collector.GetMetrics(ctx)
 
 		metricsc <- metricCollection{
 			Values: values,
-			Error:  err,
+			Error:  fmt.Errorf("getting metrics for %s failed: %w", typeName, err),
 		}
 
 		select {


### PR DESCRIPTION
If an error is returned from `GetMetrics()` it's not obvious which metric the error is relevant for.

This enhances the error to include a formatted string of the type name identifier for the metric such that it's clear for which metric it failed.