### PR TITLE
Enable adding annotations to apiservice resources

### DIFF
--- a/docs/helm/templates/custom-metrics-apiservice.yaml
+++ b/docs/helm/templates/custom-metrics-apiservice.yaml
@@ -3,6 +3,13 @@ apiVersion: apiregistration.k8s.io/v1
 kind: APIService
 metadata:
   name: v1beta1.custom.metrics.k8s.io
+  {{- with .Values.customMetricsApi.annotations }}
+  annotations:
+    {{- range $k, $v := . }}
+      {{- $value := $v | quote }}
+      {{- printf "%s: %s" (tpl $k $) (tpl $value $) | nindent 4 }}
+    {{- end }}
+  {{- end }}
 spec:
   service:
     name: kube-metrics-adapter
@@ -13,3 +20,4 @@ spec:
   groupPriorityMinimum: 100
   versionPriority: 100
 {{- end}}
+""

--- a/docs/helm/templates/external-metrics-apiservice.yaml
+++ b/docs/helm/templates/external-metrics-apiservice.yaml
@@ -3,6 +3,13 @@ apiVersion: apiregistration.k8s.io/v1
 kind: APIService
 metadata:
   name: v1beta1.external.metrics.k8s.io
+  {{- with .Values.externalMetricsApi.annotations }}
+  annotations:
+    {{- range $k, $v := . }}
+      {{- $value := $v | quote }}
+      {{- printf "%s: %s" (tpl $k $) (tpl $value $) | nindent 4 }}
+    {{- end }}
+  {{- end }}
 spec:
   service:
     name: kube-metrics-adapter

--- a/docs/helm/values.yaml
+++ b/docs/helm/values.yaml
@@ -15,7 +15,19 @@ addDirectoryHeader:
 contentionProfiling:
 profiling:
 enableCustomMetricsApi: true
+
+# -- add annotations to the custom metrics apiservice resource, e.g.
+# cert-manager.io/inject-ca-from: {{.Release.Namespace}}/kube-metrics-adapter to inject the CA certificate form a cert-manager-issued cert used for the deployment
+customMetricsApi:
+  annotations: {}
+
 enableExternalMetricsApi: true
+
+# -- add annotations to the custom metrics apiservice resource, e.g.
+# cert-manager.io/inject-ca-from: {{.Release.Namespace}}/kube-metrics-adapter to inject the CA certificate form a cert-manager-issued cert used for the deployment
+externalMetricsApi:
+  annotations: {}
+
 credentialsDirectory:
 disregardIncompatibleHPAs:
 http2MaxStreamsPerConnection:


### PR DESCRIPTION
# One-line summary

Enables adding annotations to the apiservice resources to the Helm Chart

> Issue : #864

## Description

Enables adding annotations to the apiservice resources e.g. to use cert-managers ca-injection feature in the Helm chart

## Types of Changes

- New feature (non-breaking change which adds functionality)
- Configuration change

## Tasks
_List of tasks you will do to complete the PR_
  - [x] Update templates for external and custom metrics apiservice
  - [x] Update values.yaml

## Review
_List of tasks the reviewer must do to review the PR_
- [ ] Tests
- [ ] Documentation
- [ ] CHANGELOG

## Deployment Notes
No changes necessary
