### PR TITLE
fix: Only format if there is actual an error

### DIFF
--- a/pkg/provider/hpa.go
+++ b/pkg/provider/hpa.go
@@ -384,14 +384,13 @@ func (t *CollectorScheduler) Add(resourceRef resourceReference, typeName collect
 func collectorRunner(ctx context.Context, typeName collector.MetricTypeName, collector collector.Collector, metricsc chan<- metricCollection) {
 	for {
 		values, err := collector.GetMetrics(ctx)
-
 		if err != nil {
 			err = fmt.Errorf("getting metrics for %s failed: %w", typeName, err)
 		}
 
 		metricsc <- metricCollection{
 			Values: values,
-			Error: err,
+			Error:  err,
 		}
 
 		select {


### PR DESCRIPTION
# One-line summary

only format the error if there is actual an error getting the metrics

## Description

currently on every metric collection an error is reported since Error field is not nil 

this floods the logs with something like:

```
time="2026-02-18T15:44:31Z" level=error msg="Failed to collect metrics: getting metrics for External/my-app {type=nakadi,metric-type=unconsumed-events,subscription-id=xx-xx} failed: %!w(<nil>)" provider=hpa
```

so we format the error only if the metrics collections return an error

## Types of Changes
_What types of changes does your code introduce? Keep the ones that apply:_

- Bug fix (non-breaking change which fixes an issue)

## Tasks
_List of tasks you will do to complete the PR_


## Review
_List of tasks the reviewer must do to review the PR_
- [ ] Tests
- [ ] Documentation
- [ ] CHANGELOG

## Deployment Notes
These should highlight any db migrations, feature toggles, etc.
