### PR TITLE
fix: Nil check Metric.Selector in MetricTypeName

### DIFF
--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -185,7 +185,7 @@ type MetricTypeName struct {
 
 func (m MetricTypeName) String() string {
 	str := fmt.Sprintf("%s/%s", m.Type, m.Metric.Name)
-	if len(m.Metric.Selector.MatchLabels) > 0 {
+	if m.Metric.Selector != nil && len(m.Metric.Selector.MatchLabels) > 0 {
 		str += " " + mapToString(m.Metric.Selector.MatchLabels)
 	}
 	return str


### PR DESCRIPTION
# One-line summary

Nil check Metric.Selector before try to get len()

## Description

Metric.Selector can be nil and we need to check this before we try to get the len of the MatchLabels other wise we get an error message like:

```
time="2026-02-19T11:56:57Z" level=error msg="Failed to collect metrics: getting metrics for %!s(PANIC=String method: runtime error: invalid memory address or nil pointer dereference) failed: %!w(<nil>)" provider=hpa
```

This prevents panic during error formatting, revealing the actual underlying errors instead of masking them.

## Types of Changes
_What types of changes does your code introduce? Keep the ones that apply:_

- Bug fix (non-breaking change which fixes an issue)


## Review
_List of tasks the reviewer must do to review the PR_
- [ ] Tests
- [ ] Documentation
- [ ] CHANGELOG

## Deployment Notes
These should highlight any db migrations, feature toggles, etc.
