### PR TITLE
Migrate golang-ci config to v2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
         go-version: '^1.26'
     - run: go version
     - run: go install github.com/mattn/goveralls@latest
-    - run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+    - run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4
     - run: make build.docker
     - run: make test
     - run: make check

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,13 +1,29 @@
+version: "2"
 run:
   concurrency: 4
-
 linters:
-  disable-all: true
+  default: none
   enable:
-  - errcheck
-  - gosimple
-  - govet
-  - ineffassign
-  - staticcheck
-  - typecheck
-  - unused
+    - errcheck
+    - govet
+    - ineffassign
+    - staticcheck
+    - unused
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$


### PR DESCRIPTION
Ran `golangci-lint migrate`

```
golangci-lint --version
golangci-lint has version 2.11.4 built with go1.26.1 from 8f3b0c7 on 2026-03-22T17:29:46Z
```