### PR TITLE
use net JoinHostPort that takes care of IPv6 addresses

### DIFF
--- a/pkg/collector/httpmetrics/pod_metrics.go
+++ b/pkg/collector/httpmetrics/pod_metrics.go
@@ -2,6 +2,7 @@ package httpmetrics
 
 import (
 	"fmt"
+	"net"
 	"net/url"
 	"strconv"
 	"time"
@@ -122,7 +123,7 @@ func (g *PodMetricsJSONPathGetter) buildMetricsURL(podIP string) url.URL {
 
 	return url.URL{
 		Scheme:   scheme,
-		Host:     fmt.Sprintf("%s:%d", podIP, g.port),
+		Host:     net.JoinHostPort(podIP, strconv.Itoa(g.port)),
 		Path:     g.path,
 		RawQuery: g.rawQuery,
 	}


### PR DESCRIPTION
use net JoinHostPort that takes care of IPv6 addresses

## Description
use net JoinHostPort that takes care of IPv6 addresses, otherwise the parse fail from go 1.26

## Types of Changes
_What types of changes does your code introduce? Keep the ones that apply:_

- New feature (non-breaking change which adds functionality)
- Bug fix (non-breaking change which fixes an issue)
- Configuration change
- Refactor/improvements
- Documentation / non-code

## Tasks
_List of tasks you will do to complete the PR_
  - [ ] Created Task 1
  - [ ] Created Task 2
  - [ ] To-do Task 3

## Review
_List of tasks the reviewer must do to review the PR_
- [ ] Tests
- [ ] Documentation
- [ ] CHANGELOG

## Deployment Notes
These should highlight any db migrations, feature toggles, etc.
