### PR TITLE
Remove references to registry.opensource.zalan.do

### DIFF
--- a/.github/workflows/gh-packages.yaml
+++ b/.github/workflows/gh-packages.yaml
@@ -73,7 +73,6 @@ jobs:
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294
         with:
           context: .
-          build-args: BASE_IMAGE=gcr.io/distroless/static-debian12
           platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' && startsWith(github.ref, 'refs/tags/v') }}
           tags: ${{ steps.meta.outputs.tags }}
@@ -84,7 +83,6 @@ jobs:
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294
         with:
           context: .
-          build-args: BASE_IMAGE=gcr.io/distroless/static-debian12
           platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=registry.opensource.zalan.do/library/static:latest
+ARG BASE_IMAGE=gcr.io/distroless/static-debian12:latest
 FROM ${BASE_IMAGE}
 LABEL maintainer="Team Teapot @ Zalando SE <team-teapot@zalando.de>"
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY        ?= kube-metrics-adapter
 VERSION       ?= $(shell git describe --tags --always --dirty)
-IMAGE         ?= registry-write.opensource.zalan.do/teapot/$(BINARY)
+IMAGE         ?= ghcr.io/zalando-incubator/$(BINARY)
 TAG           ?= $(VERSION)
 SOURCES       = $(shell find . -name '*.go')
 DOCKERFILE    ?= Dockerfile

--- a/delivery.yaml
+++ b/delivery.yaml
@@ -15,21 +15,6 @@ pipeline:
   - desc: test
     cmd: |
       make test
-  - desc: build
-    cmd: |
-      make build.docker
-  - desc: push
-    cmd: |
-      if [[ $CDP_TARGET_BRANCH == master && ! $CDP_PULL_REQUEST_NUMBER ]]; then
-        IMAGE=registry-write.opensource.zalan.do/teapot/kube-metrics-adapter
-        VERSION=$(git describe --tags --always)
-      else
-        IMAGE=registry-write.opensource.zalan.do/teapot/kube-metrics-adapter-test
-        VERSION=$CDP_BUILD_VERSION
-      fi
-      IMAGE=$IMAGE VERSION=$VERSION make build.docker
-      git diff --stat --exit-code
-      IMAGE=$IMAGE VERSION=$VERSION make build.push
   - desc: Build and push image to Zalando's registry
     cmd: |
       if [[ $CDP_TARGET_BRANCH == master && ! $CDP_PULL_REQUEST_NUMBER ]]; then

--- a/example/Dockerfile
+++ b/example/Dockerfile
@@ -1,7 +1,9 @@
-FROM registry.opensource.zalan.do/library/alpine-3:latest
+FROM gcr.io/distroless/static-debian12:latest
 LABEL maintainer="Team Teapot @ Zalando SE <team-teapot@zalando.de>"
 
+ARG TARGETARCH
+
 # add binary
-ADD build/linux/custom-metrics-consumer /
+ADD build/linux/${TARGETARCH}/custom-metrics-consumer /
 
 ENTRYPOINT ["/custom-metrics-consumer"]

--- a/example/Makefile
+++ b/example/Makefile
@@ -32,11 +32,14 @@ build/$(BINARY): $(SOURCES)
 build/linux/$(BINARY): $(SOURCES)
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build $(BUILD_FLAGS) -o build/linux/$(BINARY) -ldflags "$(LDFLAGS)" .
 
+build/linux/amd64/$(BINARY): $(SOURCES)
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build $(BUILD_FLAGS) -o build/linux/amd64/$(BINARY) -ldflags "$(LDFLAGS)" .
+
+build/linux/arm64/$(BINARY): $(SOURCES)
+	GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build $(BUILD_FLAGS) -o build/linux/arm64/$(BINARY) -ldflags "$(LDFLAGS)" .
+
 build/osx/$(BINARY): $(SOURCES)
 	GOOS=darwin GOARCH=amd64 CGO_ENABLED=0 go build $(BUILD_FLAGS) -o build/osx/$(BINARY) -ldflags "$(LDFLAGS)" .
 
-build.docker: build.linux
-	docker build --rm -t "$(IMAGE):$(TAG)" -f $(DOCKERFILE) .
-
-build.push: build.docker
-	docker push "$(IMAGE):$(TAG)"
+build.push: build/linux/amd64/$(BINARY) build/linux/arm64/$(BINARY)
+	docker buildx build --rm --build-arg -t "$(IMAGE):$(TAG)" --platform linux/amd64,linux/arm64 --push .


### PR DESCRIPTION
Zalando wants to decommission the docker registry hosting images on `registry.opensource.zalan.do`

This removes any reference to `registry.opensource.zalan.do` and replaces with open source images where applicable.

We provide public images via ghcr.io: https://github.com/zalando-incubator/kube-metrics-adapter/pkgs/container/kube-metrics-adapter