### PR TITLE
Use github native code quality tool

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,11 +15,18 @@ jobs:
       with:
         go-version: '^1.26'
     - run: go version
-    - run: go install github.com/mattn/goveralls@latest
+    - run: go install github.com/t-yuki/gocover-cobertura@latest
     - run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
     - run: make build.docker
     - run: make test
     - run: make check
-    - run: goveralls -coverprofile=profile.cov -service=github
-      env:
-        COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Convert coverage to Cobertura XML
+      if: ${{ hashFiles('profile.cov') != '' }}
+      run: gocover-cobertura < profile.cov > coverage.xml
+    - name: Upload coverage report
+      if: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && hashFiles('coverage.xml') != '' }}
+      uses: actions/upload-code-coverage@v1
+      with:
+        file: coverage.xml
+        language: go
+        label: code-coverage/go-test

--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
 # kube-metrics-adapter
-[![Build Status](https://travis-ci.org/zalando-incubator/kube-metrics-adapter.svg?branch=master)](https://travis-ci.org/zalando-incubator/kube-metrics-adapter)
-[![Coverage Status](https://coveralls.io/repos/github/zalando-incubator/kube-metrics-adapter/badge.svg?branch=master)](https://coveralls.io/github/zalando-incubator/kube-metrics-adapter?branch=master)
 
 Kube Metrics Adapter is a general purpose metrics adapter for Kubernetes that
 can collect and serve custom and external metrics for Horizontal Pod


### PR DESCRIPTION
Use github native code quality tool as outlined in https://docs.github.com/en/code-security/how-tos/maintain-quality-code/set-up-code-coverage instead of coveralls.