### PR TITLE
Bugfix for #906: subscription selector

### DIFF
--- a/pkg/collector/nakadi_collector.go
+++ b/pkg/collector/nakadi_collector.go
@@ -85,7 +85,14 @@ func NewNakadiCollector(_ context.Context, nakadiClient nakadi.Nakadi, hpa *auto
 	}
 
 	if nakadiEventTypes, ok := config.Config[nakadiEventTypesKey]; ok {
-		eventTypes := strings.Split(nakadiEventTypes, ",")
+		eventTypes := make([]string, 0)
+		for _, eventType := range strings.Split(nakadiEventTypes, ",") {
+			eventType = strings.TrimSpace(eventType)
+			if eventType == "" {
+				continue
+			}
+			eventTypes = append(eventTypes, eventType)
+		}
 		subscriptionFilter.EventTypes = eventTypes
 	}
 

--- a/pkg/collector/nakadi_collector_test.go
+++ b/pkg/collector/nakadi_collector_test.go
@@ -1,0 +1,70 @@
+package collector
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestNewNakadiCollectorTrimsEventTypes(t *testing.T) {
+	hpa := &autoscalingv2.HorizontalPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+		},
+	}
+
+	config := &MetricConfig{
+		MetricTypeName: MetricTypeName{
+			Type: autoscalingv2.ExternalMetricSourceType,
+			Metric: autoscalingv2.MetricIdentifier{
+				Name: "nakadi-metric",
+				Selector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"type": NakadiMetricType},
+				},
+			},
+		},
+		Config: map[string]string{
+			nakadiMetricTypeKey:        nakadiMetricTypeUnconsumedEvents,
+			nakadiOwningApplicationKey: "example-app",
+			nakadiEventTypesKey:        "event-a, event-b,   ,event-c  ",
+			nakadiConsumerGroupKey:     "example-group",
+		},
+	}
+
+	collector, err := NewNakadiCollector(context.Background(), nil, hpa, config, time.Second)
+	require.NoError(t, err)
+	require.Equal(t, []string{"event-a", "event-b", "event-c"}, collector.subscriptionFilter.EventTypes)
+}
+
+func TestNewNakadiCollectorRejectsBlankEventTypesAfterTrim(t *testing.T) {
+	hpa := &autoscalingv2.HorizontalPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+		},
+	}
+
+	config := &MetricConfig{
+		MetricTypeName: MetricTypeName{
+			Type: autoscalingv2.ExternalMetricSourceType,
+			Metric: autoscalingv2.MetricIdentifier{
+				Name: "nakadi-metric",
+				Selector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"type": NakadiMetricType},
+				},
+			},
+		},
+		Config: map[string]string{
+			nakadiMetricTypeKey:        nakadiMetricTypeUnconsumedEvents,
+			nakadiOwningApplicationKey: "example-app",
+			nakadiEventTypesKey:        "  , ,  ",
+			nakadiConsumerGroupKey:     "example-group",
+		},
+	}
+
+	_, err := NewNakadiCollector(context.Background(), nil, hpa, config, time.Second)
+	require.EqualError(t, err, "either subscription-id or all of [owning-application, event-types, consumer-group] must be specified on the metric")
+}

--- a/pkg/nakadi/nakadi.go
+++ b/pkg/nakadi/nakadi.go
@@ -253,10 +253,20 @@ func (c *Client) stats(ctx context.Context, filter *SubscriptionFilter) ([]stats
 		}
 
 		if len(result.Items) == 0 {
-			return nil, errors.New("[nakadi stats] expected at least 1 event-type, 0 returned")
+			// Filtering mode can resolve multiple subscriptions. Some of them may
+			// temporarily return no event-type stats, so continue collecting from
+			// the remaining subscriptions and fail only if none yield data.
+			if filter.SubscriptionID != "" {
+				return nil, errors.New("[nakadi stats] expected at least 1 event-type, 0 returned")
+			}
+			continue
 		}
 
 		stats = append(stats, result.Items...)
+	}
+
+	if len(stats) == 0 {
+		return nil, errors.New("[nakadi stats] expected at least 1 event-type, 0 returned")
 	}
 
 	return stats, nil

--- a/pkg/nakadi/nakadi_test.go
+++ b/pkg/nakadi/nakadi_test.go
@@ -40,6 +40,8 @@ func TestQuery(tt *testing.T) {
 		msg                        string
 		status                     int
 		subscriptionIDResponseBody string
+		subscriptionIDResponseByID map[string]string
+		subscriptionIDStatusByID   map[string]int
 		subscriptionFilter         *SubscriptionFilter
 		err                        error
 		unconsumedEvents           int64
@@ -178,6 +180,35 @@ func TestQuery(tt *testing.T) {
 			unconsumedEvents:   18,
 			consumerLagSeconds: 2,
 		},
+		{
+			msg:                "test filtering ignores subscriptions with empty stats response",
+			status:             http.StatusOK,
+			subscriptionFilter: &SubscriptionFilter{OwningApplication: "example-app", EventTypes: []string{"example-event"}, ConsumerGroup: "example-group"},
+			subscriptionIDResponseByID: map[string]string{
+				"id_1": `{
+					"items": []
+				}`,
+				"id_2": `{
+					"items": [
+						{
+							"event_type": "example-event",
+							"partitions": [
+								{
+									"partition": "0",
+									"state": "assigned",
+									"unconsumed_events": 7,
+									"consumer_lag_seconds": 5,
+									"stream_id": "example-id",
+									"assignment_type": "auto"
+								}
+							]
+						}
+					]
+				}`,
+			},
+			unconsumedEvents:   7,
+			consumerLagSeconds: 5,
+		},
 	} {
 		tt.Run(ti.msg, func(t *testing.T) {
 			mux := http.NewServeMux()
@@ -203,8 +234,20 @@ func TestQuery(tt *testing.T) {
 				assert.NoError(t, err)
 			})
 			mux.HandleFunc("/subscriptions/{id}/stats", func(w http.ResponseWriter, r *http.Request) {
-				w.WriteHeader(ti.status)
-				_, err := w.Write([]byte(ti.subscriptionIDResponseBody))
+				subscriptionID := r.PathValue("id")
+
+				status := ti.status
+				if s, ok := ti.subscriptionIDStatusByID[subscriptionID]; ok {
+					status = s
+				}
+
+				body := ti.subscriptionIDResponseBody
+				if b, ok := ti.subscriptionIDResponseByID[subscriptionID]; ok {
+					body = b
+				}
+
+				w.WriteHeader(status)
+				_, err := w.Write([]byte(body))
 				assert.NoError(t, err)
 			})
 			ts := httptest.NewServer(mux)


### PR DESCRIPTION
Clean split between selector by `subscription-id` or `owning-application / event-types / consumer-group` correctly
> Issue : #906 

Small improvement:
"type-a, type-b"  lead to errors due to the leading space in  " type-b"
